### PR TITLE
Reduced memory/disk demands for cloud.gov.

### DIFF
--- a/truffles_manifest.yml
+++ b/truffles_manifest.yml
@@ -2,9 +2,9 @@ applications:
 - name: truffles
   path: ./build
   buildpack: staticfile_buildpack
-  disk_quota: 1G
+  disk_quota: 32M
   instances: 1
-  memory: 512M
+  memory: 32M
   routes:
   - route: truffles.app.cloud.gov
   stack: cflinuxfs3


### PR DESCRIPTION
Since cloud.gov has a quota for sandbox users, and allocating ten times what we need was not a good use of that quota.