### PR TITLE
Use API base url environment variable if provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ Launches the test runner and collects code coverage. Outputs results to the `/co
 Builds the app for production to the `build` folder.<br>
 It correctly bundles React in production mode and optimizes the build for the best performance.
 
+#### BaseUrl Environment Variable
+
+By default, the base URL is assumed to be the local Spring back-end url, `http://localhost:8080`. If building for a different environment, simply add the `REACT_APP_API_BASE_URL` environment variable. For example, if the API is located at `https://truffles-api.app.cloud.gov`, you could build the application using the following command:
+
+```bash
+REACT_APP_API_BASE_URL=https://truffles-api.app.cloud.gov yarn build
+```
+
 The build is minified and the filenames include the hashes.<br>
 Your app is ready to be deployed!
 

--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ import { UsaAlert } from "./view/util/UsaAlert";
 import configureCaseFetcher from "./model/caseFetcher";
 import { ActiveCaseList } from "./view/caselists/ActiveCaseList";
 import { SnoozedCaseList } from "./view/caselists/SnoozedCaseList";
-import { BASE_URL, VIEWS, I90_HEADERS } from "./controller/config";
+import { API_BASE_URL, VIEWS, I90_HEADERS } from "./controller/config";
 import { getHeaders } from "./view/util/getHeaders";
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
@@ -18,7 +18,7 @@ import "react-toastify/dist/ReactToastify.css";
 library.add(fas);
 
 const caseFetcher = configureCaseFetcher({
-  baseUrl: BASE_URL,
+  baseUrl: API_BASE_URL,
   resultsPerPage: 20
 });
 

--- a/src/controller/config.js
+++ b/src/controller/config.js
@@ -39,7 +39,8 @@ const SNOOZE_OPTIONS = [
   }
 ];
 
-const BASE_URL = "http://localhost:8080";
+const API_BASE_URL =
+  process.env.REACT_APP_API_BASE_URL || "http://localhost:8080";
 
 const CASE_MANAGEMENT_SYSTEM = "DEFAULT";
 
@@ -147,7 +148,7 @@ const I90_HEADERS = [
 ];
 
 export {
-  BASE_URL,
+  API_BASE_URL,
   CASE_MANAGEMENT_SYSTEM,
   CASE_TYPE,
   ELIS_CASE_BASE_URL,


### PR DESCRIPTION
## Proposed changes

This is one way to have a build-based API URL environment variable. While we discussed other end-state solutions, this is the quickest way to get something working that should allow us to build the app for cloud.gov.

When running locally, you can still use `yarn start` or `yarn build`

When building for cloud.gov, you can add the environment variable when running the build command:

```
REACT_APP_API_BASE_URL=https://truffles-api.app.cloud.gov yarn build
```

After that, follow the normal cloud.gov deployment steps.