### PR TITLE
Fix Platform SP/Legacy display

### DIFF
--- a/src/controller/config.js
+++ b/src/controller/config.js
@@ -135,7 +135,7 @@ const I90_HEADERS = [
   {
     header: "Platform",
     field: "extraData",
-    content: d => (d.streamlinedProcess === "true" ? "SP" : "Legacy"),
+    content: d => (d.streamlinedProcess === true ? "SP" : "Legacy"),
     views: [VIEWS.CASES_TO_WORK.TITLE, VIEWS.SNOOZED_CASES.TITLE]
   },
   {

--- a/src/stories/__snapshots__/storyshots.test.js.snap
+++ b/src/stories/__snapshots__/storyshots.test.js.snap
@@ -263,7 +263,7 @@ exports[`Storyshots ReceiptList Snoozed Case List with an open details accordion
         </a>
       </td>
       <td>
-        Legacy
+        SP
       </td>
       <td>
         Just Because
@@ -324,7 +324,7 @@ exports[`Storyshots ReceiptList Snoozed Case List with an open details accordion
         </a>
       </td>
       <td>
-        Legacy
+        SP
       </td>
       <td>
         Just Because
@@ -564,7 +564,7 @@ exports[`Storyshots ReceiptList Tabular Cases-to-Work List with some items 1`] =
         Amazingly Successful
       </td>
       <td>
-        Legacy
+        SP
       </td>
       <td />
       <td>
@@ -733,7 +733,7 @@ exports[`Storyshots ReceiptList Tabular Snoozed Case List with some items 1`] = 
         </a>
       </td>
       <td>
-        Legacy
+        SP
       </td>
       <td>
         Just Because


### PR DESCRIPTION
## Proposed change

This fixes a hold-over from a previous iteration of the tool where `streamlinedProcess` was prototyped as a string rather than a boolean.