### PR TITLE
Add oauth integration on 401 error

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,37 +8,40 @@ import { ActiveCaseList } from "./view/caselists/ActiveCaseList";
 import { SnoozedCaseList } from "./view/caselists/SnoozedCaseList";
 import { VIEWS } from "./controller/config";
 import { Layout } from "./view/layout/Layout";
+import { AuthContainer } from "./view/auth/AuthContainer";
 
 library.add(fas);
 
 const App = () => (
-  <Layout
-    render={(updateSummaryData, setNotification, summary) => (
-      <React.Fragment>
-        <Route
-          path="/"
-          exact={true}
-          render={() => (
-            <ActiveCaseList
-              updateSummaryData={updateSummaryData}
-              setNotification={setNotification}
-              summary={summary}
-            />
-          )}
-        />
-        <Route
-          path={`/${VIEWS.SNOOZED_CASES.ROUTE}`}
-          render={() => (
-            <SnoozedCaseList
-              updateSummaryData={updateSummaryData}
-              setNotification={setNotification}
-              summary={summary}
-            />
-          )}
-        />
-      </React.Fragment>
-    )}
-  />
+  <AuthContainer>
+    <Layout
+      render={(updateSummaryData, setNotification, summary) => (
+        <React.Fragment>
+          <Route
+            path="/"
+            exact={true}
+            render={() => (
+              <ActiveCaseList
+                updateSummaryData={updateSummaryData}
+                setNotification={setNotification}
+                summary={summary}
+              />
+            )}
+          />
+          <Route
+            path={`/${VIEWS.SNOOZED_CASES.ROUTE}`}
+            render={() => (
+              <SnoozedCaseList
+                updateSummaryData={updateSummaryData}
+                setNotification={setNotification}
+                summary={summary}
+              />
+            )}
+          />
+        </React.Fragment>
+      )}
+    />
+  </AuthContainer>
 );
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,7 @@ import { AuthContainer } from "./view/auth/AuthContainer";
 library.add(fas);
 
 const App = () => (
-  <AuthContainer>
+  <AuthContainer defaultLoggedInState={true}>
     <Layout
       render={(updateSummaryData, setError, setNotification, summary) => (
         <React.Fragment>

--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,7 @@ library.add(fas);
 const App = () => (
   <AuthContainer>
     <Layout
-      render={(updateSummaryData, setNotification, summary) => (
+      render={(updateSummaryData, setError, setNotification, summary) => (
         <React.Fragment>
           <Route
             path="/"
@@ -25,6 +25,7 @@ const App = () => (
                 updateSummaryData={updateSummaryData}
                 setNotification={setNotification}
                 summary={summary}
+                setError={setError}
               />
             )}
           />
@@ -35,6 +36,7 @@ const App = () => (
                 updateSummaryData={updateSummaryData}
                 setNotification={setNotification}
                 summary={summary}
+                setError={setError}
               />
             )}
           />

--- a/src/stories/__snapshots__/storyshots.test.js.snap
+++ b/src/stories/__snapshots__/storyshots.test.js.snap
@@ -1,5 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots AuthForm AuthForm view 1`] = `
+<div
+  className="overlay"
+>
+  <div
+    className="item"
+  >
+    <p>
+      To use the Search Party tool, you must be logged in to USCIS.
+    </p>
+    <p>
+      <a
+        className="usa-button usa-button--primary"
+        href="#test-link"
+      >
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-user-circle fa-w-16 "
+          data-icon="user-circle"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 496 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M248 8C111 8 0 119 0 256s111 248 248 248 248-111 248-248S385 8 248 8zm0 96c48.6 0 88 39.4 88 88s-39.4 88-88 88-88-39.4-88-88 39.4-88 88-88zm0 344c-58.7 0-111.3-26.6-146.5-68.2 18.8-35.4 55.6-59.8 98.5-59.8 2.4 0 4.8.4 7.1 1.1 13 4.2 26.6 6.9 40.9 6.9 14.3 0 28-2.7 40.9-6.9 2.3-.7 4.7-1.1 7.1-1.1 42.9 0 79.7 24.4 98.5 59.8C359.3 421.4 306.7 448 248 448z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+          Log In to USCIS
+      </a>
+    </p>
+  </div>
+</div>
+`;
+
 exports[`Storyshots CaseList Case list while loading data 1`] = `
 Array [
   <table

--- a/src/stories/auth/Auth.stories.jsx
+++ b/src/stories/auth/Auth.stories.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { AuthForm } from "../../view/auth/AuthForm";
+
+storiesOf("AuthForm", module).add("AuthForm view", () => (
+  <AuthForm loginUrl={"#test-link"} />
+));

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,9 +120,8 @@ export type ToastOptions = {
 };
 
 export type Error = {
-  error?: string;
-  message?: string;
-  path?: string;
-  status?: number;
-  timestamp?: string;
-} | null;
+  error: string;
+  message: string;
+  status: number;
+  timestamp: string;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,3 +99,30 @@ export type CaseDetail = {
   href?: string | null;
   content?: string;
 };
+
+export type NotificationType =
+  | "info"
+  | "success"
+  | "warning"
+  | "error"
+  | "default"
+  | undefined;
+
+export type Notification = {
+  message: string;
+  type: NotificationType;
+  id?: string;
+} | null;
+
+export type ToastOptions = {
+  type: NotificationType;
+  toastId?: string;
+};
+
+export type Error = {
+  error?: string;
+  message?: string;
+  path?: string;
+  status?: number;
+  timestamp?: string;
+} | null;

--- a/src/view/auth/AuthContainer.tsx
+++ b/src/view/auth/AuthContainer.tsx
@@ -1,0 +1,21 @@
+import React, { useState } from "react";
+import { AuthForm } from "./AuthForm";
+
+type AuthContext = {
+  loggedIn: boolean;
+  setLoggedIn: React.Dispatch<boolean>;
+};
+
+export const AuthContext = React.createContext({} as AuthContext);
+
+const AuthContainer: React.FC = props => {
+  const [loggedIn, setLoggedIn] = useState<boolean>(true);
+
+  return (
+    <AuthContext.Provider value={{ loggedIn, setLoggedIn }}>
+      {loggedIn ? props.children : <AuthForm />}
+    </AuthContext.Provider>
+  );
+};
+
+export { AuthContainer };

--- a/src/view/auth/AuthContainer.tsx
+++ b/src/view/auth/AuthContainer.tsx
@@ -1,19 +1,30 @@
 import React, { useState } from "react";
 import { AuthForm } from "./AuthForm";
+import { API_BASE_URL } from "../../controller/config";
 
 type AuthContext = {
   loggedIn: boolean;
   setLoggedIn: React.Dispatch<boolean>;
 };
 
+interface AuthContainerProps {
+  defaultLoggedInState: boolean;
+}
+
 export const AuthContext = React.createContext({} as AuthContext);
 
-const AuthContainer: React.FC = props => {
-  const [loggedIn, setLoggedIn] = useState<boolean>(true);
+const AuthContainer: React.FC<AuthContainerProps> = props => {
+  const [loggedIn, setLoggedIn] = useState<boolean>(props.defaultLoggedInState);
 
   return (
     <AuthContext.Provider value={{ loggedIn, setLoggedIn }}>
-      {loggedIn ? props.children : <AuthForm />}
+      {loggedIn ? (
+        props.children
+      ) : (
+        <AuthForm
+          loginUrl={`${API_BASE_URL}/clientLogin/?redirect=${window.location}`}
+        />
+      )}
     </AuthContext.Provider>
   );
 };

--- a/src/view/auth/AuthForm.css
+++ b/src/view/auth/AuthForm.css
@@ -1,0 +1,15 @@
+.overlay {
+  background-color: #fff;
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: table;
+  text-align: center;
+}
+
+.overlay .item {
+  display: table-cell;
+  vertical-align: middle;
+}

--- a/src/view/auth/AuthForm.tsx
+++ b/src/view/auth/AuthForm.tsx
@@ -1,19 +1,19 @@
 import React from "react";
 import "./AuthForm.css";
-import { API_BASE_URL } from "../../controller/config";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faUserCircle } from "@fortawesome/free-solid-svg-icons";
 
-const AuthForm: React.FC = () => {
+interface AuthFormProps {
+  loginUrl: string;
+}
+
+const AuthForm: React.FC<AuthFormProps> = props => {
   return (
     <div className="overlay">
       <div className="item">
         <p>To use the Search Party tool, you must be logged in to USCIS.</p>
         <p>
-          <a
-            href={`${API_BASE_URL}/clientLogin/?redirect=${window.location}`}
-            className="usa-button usa-button--primary "
-          >
+          <a href={props.loginUrl} className="usa-button usa-button--primary">
             <FontAwesomeIcon icon={faUserCircle}></FontAwesomeIcon>&nbsp; Log In
             to USCIS
           </a>

--- a/src/view/auth/AuthForm.tsx
+++ b/src/view/auth/AuthForm.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import "./AuthForm.css";
+import { API_BASE_URL } from "../../controller/config";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faUserCircle } from "@fortawesome/free-solid-svg-icons";
+
+const AuthForm: React.FC = () => {
+  return (
+    <div className="overlay">
+      <div className="item">
+        <p>To use the Search Party tool, you must be logged in to USCIS.</p>
+        <p>
+          <a
+            href={`${API_BASE_URL}/clientLogin/?redirect=${window.location}`}
+            className="usa-button usa-button--primary "
+          >
+            <FontAwesomeIcon icon={faUserCircle}></FontAwesomeIcon>&nbsp; Log In
+            to USCIS
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export { AuthForm };

--- a/src/view/auth/__test__/AuthContainer.test.js
+++ b/src/view/auth/__test__/AuthContainer.test.js
@@ -1,0 +1,27 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { AuthContainer } from "../AuthContainer";
+import { AuthForm } from "../AuthForm";
+
+const TestComponent = () => <div>Test Component</div>;
+
+describe("AuthContainer", () => {
+  it("should render children if logged in", () => {
+    const wrapper = shallow(
+      <AuthContainer defaultLoggedInState={true}>
+        <TestComponent />
+      </AuthContainer>
+    );
+    expect(wrapper.find(TestComponent).length).toBe(1);
+    expect(wrapper.find(AuthForm).length).toBe(0);
+  });
+  it("should render AuthForm if not logged id", () => {
+    const wrapper = shallow(
+      <AuthContainer defaultLoggedInState={false}>
+        <TestComponent />
+      </AuthContainer>
+    );
+    expect(wrapper.find(TestComponent).length).toBe(0);
+    expect(wrapper.find(AuthForm).length).toBe(1);
+  });
+});

--- a/src/view/caselists/ActiveCaseList.jsx
+++ b/src/view/caselists/ActiveCaseList.jsx
@@ -38,10 +38,9 @@ const ActiveCaseList = props => {
 
       if (response.responseReceived) {
         const errorJson = await response.responseError.getJson();
-        setError(errorJson);
+        !cancelRequest && setError(errorJson);
       } else {
-        // Workaround for lack of 401 response
-        setError({ status: 401 });
+        console.error(response);
       }
     })(currentPage);
 
@@ -79,8 +78,7 @@ const ActiveCaseList = props => {
       const errorJson = await response.responseError.getJson();
       setError(errorJson);
     } else {
-      // Workaround for lack of 401 response
-      setError({ status: 401 });
+      console.error(response);
     }
   };
 

--- a/src/view/caselists/ActiveCaseList.jsx
+++ b/src/view/caselists/ActiveCaseList.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { CaseList } from "./CaseList";
 import { VIEWS, I90_HEADERS } from "../../controller/config";
@@ -7,11 +7,8 @@ import SnoozeForm from "../../controller/SnoozeForm";
 import { formatNotes } from "../util/formatNotes";
 import RestAPIClient from "../../model/RestAPIClient";
 import { DesnoozedWarning } from "../notifications/DesnoozedWarning";
-import { AuthContext } from "../auth/AuthContainer";
 
 const ActiveCaseList = props => {
-  const { setLoggedIn } = useContext(AuthContext);
-
   const [cases, setCases] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [currentPage, setCurrentPage] = useState(0);
@@ -47,7 +44,7 @@ const ActiveCaseList = props => {
     return () => {
       cancelRequest = true;
     };
-  }, [currentPage, setIsLoading, setNotification, setLoggedIn, setError]);
+  }, [currentPage, setIsLoading, setNotification, setError]);
 
   const snooze = async (rowData, snoozeOption) => {
     const notes = formatNotes(snoozeOption);

--- a/src/view/caselists/ActiveCaseList.jsx
+++ b/src/view/caselists/ActiveCaseList.jsx
@@ -17,9 +17,15 @@ const ActiveCaseList = props => {
   const { setNotification, summary } = props;
 
   useEffect(() => {
+    let cancelRequest = false;
+
     setIsLoading(true);
     (async page => {
       const response = await RestAPIClient.cases.getActive(page);
+      if (cancelRequest) {
+        return;
+      }
+
       setIsLoading(false);
       if (response.succeeded) {
         return setCases(previousCases => [
@@ -36,6 +42,10 @@ const ActiveCaseList = props => {
         console.error(errorJson);
       }
     })(currentPage);
+
+    return () => {
+      cancelRequest = true;
+    };
   }, [currentPage, setIsLoading, setNotification]);
 
   const snooze = async (rowData, snoozeOption) => {

--- a/src/view/caselists/SnoozedCaseList.jsx
+++ b/src/view/caselists/SnoozedCaseList.jsx
@@ -31,10 +31,9 @@ const SnoozedCaseList = props => {
 
       if (response.responseReceived) {
         const errorJson = await response.responseError.getJson();
-        setError(errorJson);
+        !cancelRequest && setError(errorJson);
       } else {
-        // Workaround for lack of 401 response
-        setError({ status: 401 });
+        console.error(response);
       }
     })(currentPage);
 
@@ -97,8 +96,7 @@ const SnoozedCaseList = props => {
       const errorJson = await response.responseError.getJson();
       setError(errorJson);
     } else {
-      // Workaround for lack of 401 response
-      setError({ status: 401 });
+      console.error(response);
     }
   };
 
@@ -124,8 +122,7 @@ const SnoozedCaseList = props => {
       const errorJson = await response.responseError.getJson();
       setError(errorJson);
     } else {
-      // Workaround for lack of 401 response
-      setError({ status: 401 });
+      console.error(response);
     }
   };
 

--- a/src/view/caselists/SnoozedCaseList.jsx
+++ b/src/view/caselists/SnoozedCaseList.jsx
@@ -12,7 +12,7 @@ const SnoozedCaseList = props => {
   const [isLoading, setIsLoading] = useState(false);
   const [currentPage, setCurrentPage] = useState(0);
 
-  const { setNotification, summary } = props;
+  const { setNotification, setError, summary } = props;
 
   useEffect(() => {
     let cancelRequest = false;
@@ -28,20 +28,20 @@ const SnoozedCaseList = props => {
         setCases(previousCases => [...previousCases, ...response.payload]);
         return setIsLoading(false);
       }
-      setNotification({
-        message: "There was an error loading cases.",
-        type: "error"
-      });
+
       if (response.responseReceived) {
         const errorJson = await response.responseError.getJson();
-        console.error(errorJson);
+        setError(errorJson);
+      } else {
+        // Workaround for lack of 401 response
+        setError({ status: 401 });
       }
     })(currentPage);
 
     return () => {
       cancelRequest = true;
     };
-  }, [setCases, currentPage, setNotification]);
+  }, [setCases, currentPage, setNotification, setError]);
 
   const reSnooze = async (rowData, snoozeOption) => {
     const notes = formatNotes(snoozeOption);
@@ -93,13 +93,12 @@ const SnoozedCaseList = props => {
       return setCases(snoozedCases);
     }
 
-    setNotification({
-      message: "There was an error saving the snooze.",
-      type: "error"
-    });
     if (response.responseReceived) {
       const errorJson = await response.responseError.getJson();
-      console.error(errorJson);
+      setError(errorJson);
+    } else {
+      // Workaround for lack of 401 response
+      setError({ status: 401 });
     }
   };
 
@@ -121,13 +120,12 @@ const SnoozedCaseList = props => {
       });
     }
 
-    setNotification({
-      message: "There was an error unsnoozing this case.",
-      type: "error"
-    });
     if (response.responseReceived) {
       const errorJson = await response.responseError.getJson();
-      console.error(errorJson);
+      setError(errorJson);
+    } else {
+      // Workaround for lack of 401 response
+      setError({ status: 401 });
     }
   };
 
@@ -169,7 +167,8 @@ const SnoozedCaseList = props => {
 SnoozedCaseList.propTypes = {
   setNotification: PropTypes.func.isRequired,
   summary: PropTypes.object.isRequired,
-  updateSummaryData: PropTypes.func.isRequired
+  updateSummaryData: PropTypes.func.isRequired,
+  setError: PropTypes.func.isRequired
 };
 
 export { SnoozedCaseList };

--- a/src/view/caselists/SnoozedCaseList.jsx
+++ b/src/view/caselists/SnoozedCaseList.jsx
@@ -15,9 +15,15 @@ const SnoozedCaseList = props => {
   const { setNotification, summary } = props;
 
   useEffect(() => {
+    let cancelRequest = false;
+
     setIsLoading(true);
     (async page => {
       const response = await RestAPIClient.cases.getSnoozed(page);
+      if (cancelRequest) {
+        return;
+      }
+
       if (response.succeeded) {
         setCases(previousCases => [...previousCases, ...response.payload]);
         return setIsLoading(false);
@@ -31,6 +37,10 @@ const SnoozedCaseList = props => {
         console.error(errorJson);
       }
     })(currentPage);
+
+    return () => {
+      cancelRequest = true;
+    };
   }, [setCases, currentPage, setNotification]);
 
   const reSnooze = async (rowData, snoozeOption) => {

--- a/src/view/layout/ErrorHandler.tsx
+++ b/src/view/layout/ErrorHandler.tsx
@@ -12,7 +12,7 @@ const ErrorHandler: React.FC<ErrorHandlerProps> = props => {
   const { setLoggedIn } = useContext(AuthContext);
 
   useEffect(() => {
-    if (!error.message) {
+    if (error.status === undefined) {
       return;
     }
     if (error.status === 401) {

--- a/src/view/layout/ErrorHandler.tsx
+++ b/src/view/layout/ErrorHandler.tsx
@@ -12,7 +12,7 @@ const ErrorHandler: React.FC<ErrorHandlerProps> = props => {
   const { setLoggedIn } = useContext(AuthContext);
 
   useEffect(() => {
-    if (!error) {
+    if (!error.message) {
       return;
     }
     if (error.status === 401) {

--- a/src/view/layout/ErrorHandler.tsx
+++ b/src/view/layout/ErrorHandler.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useContext } from "react";
+import { Notification, Error } from "./Layout";
+import { AuthContext } from "../auth/AuthContainer";
+
+interface ErrorHandlerProps {
+  setNotification: React.Dispatch<Notification>;
+  error: Error;
+}
+
+const ErrorHandler: React.FC<ErrorHandlerProps> = props => {
+  const { error, setNotification } = props;
+  const { setLoggedIn } = useContext(AuthContext);
+
+  useEffect(() => {
+    if (!error) {
+      return;
+    }
+    if (error.status === 401) {
+      setLoggedIn(false);
+    } else if (error.status === 403) {
+      setNotification({
+        message: "You do not have access to this system.",
+        type: "error"
+      });
+    } else {
+      console.error(error);
+    }
+  }, [error, setNotification, setLoggedIn]);
+
+  return <React.Fragment />;
+};
+
+export { ErrorHandler };

--- a/src/view/layout/ErrorHandler.tsx
+++ b/src/view/layout/ErrorHandler.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useContext } from "react";
-import { Notification, Error } from "./Layout";
 import { AuthContext } from "../auth/AuthContainer";
+import { Error, Notification } from "../../types";
 
 interface ErrorHandlerProps {
   setNotification: React.Dispatch<Notification>;

--- a/src/view/layout/Layout.tsx
+++ b/src/view/layout/Layout.tsx
@@ -23,7 +23,7 @@ const Layout: React.FunctionComponent<LayoutProps> = props => {
     SNOOZED_CASES: 0,
     PREVIOUSLY_SNOOZED: 0
   });
-  const [error, setError] = useState<Error>(null);
+  const [error, setError] = useState<Error>({} as Error);
   const [notification, setNotification] = useState<Notification>(null);
   const [updateSummary, setUpdateSummary] = useState<boolean>(false);
 
@@ -68,7 +68,7 @@ const Layout: React.FunctionComponent<LayoutProps> = props => {
       }
       if (response.responseReceived) {
         const errorJson = await response.responseError.getJson();
-        setError(errorJson);
+        setError(errorJson as Error);
       } else {
         console.error(response);
       }

--- a/src/view/layout/Layout.tsx
+++ b/src/view/layout/Layout.tsx
@@ -45,7 +45,11 @@ interface LayoutProps {
 }
 
 const Layout: React.FunctionComponent<LayoutProps> = props => {
-  const [summary, setSummary] = useState<Summary>({} as Summary);
+  const [summary, setSummary] = useState<Summary>({
+    CASES_TO_WORK: 0,
+    SNOOZED_CASES: 0,
+    PREVIOUSLY_SNOOZED: 0
+  });
   const [error, setError] = useState<Error>(null);
   const [notification, setNotification] = useState<Notification>(null);
   const [updateSummary, setUpdateSummary] = useState<boolean>(false);
@@ -93,8 +97,7 @@ const Layout: React.FunctionComponent<LayoutProps> = props => {
         const errorJson = await response.responseError.getJson();
         setError(errorJson);
       } else {
-        // Workaround for lack of 401 response
-        setError({ status: 401 });
+        console.error(response);
       }
     };
     updateSummaryData();

--- a/src/view/layout/Layout.tsx
+++ b/src/view/layout/Layout.tsx
@@ -45,8 +45,14 @@ const Layout: React.FunctionComponent<LayoutProps> = props => {
       return;
     }
 
+    let cancelRequest = false;
+
     const updateSummaryData = async () => {
       const response = await RestAPIClient.cases.getCaseSummary();
+      if (cancelRequest) {
+        return;
+      }
+
       if (response.succeeded) {
         const currentlySnoozed = response.payload.CURRENTLY_SNOOZED || 0;
         const neverSnoozed = response.payload.NEVER_SNOOZED || 0;
@@ -64,6 +70,10 @@ const Layout: React.FunctionComponent<LayoutProps> = props => {
       }
     };
     updateSummaryData();
+
+    return () => {
+      cancelRequest = true;
+    };
   }, [updateSummary]);
 
   return (

--- a/src/view/layout/Layout.tsx
+++ b/src/view/layout/Layout.tsx
@@ -4,36 +4,9 @@ import PrimaryNavMenu from "./PrimaryNavMenu";
 import { VIEWS } from "../../controller/config";
 import FormattedDate from "../util/FormattedDate";
 import "react-toastify/dist/ReactToastify.css";
-import { Summary } from "../../types";
+import { Summary, Error, Notification, ToastOptions } from "../../types";
 import RestAPIClient from "../../model/RestAPIClient";
 import { ErrorHandler } from "./ErrorHandler";
-
-type NotificationType =
-  | "info"
-  | "success"
-  | "warning"
-  | "error"
-  | "default"
-  | undefined;
-
-export type Notification = {
-  message: string;
-  type: NotificationType;
-  id?: string;
-} | null;
-
-type ToastOptions = {
-  type: NotificationType;
-  toastId?: string;
-};
-
-export type Error = {
-  error?: string;
-  message?: string;
-  path?: string;
-  status?: number;
-  timestamp?: string;
-} | null;
 
 interface LayoutProps {
   render: (

--- a/src/view/layout/PrimaryNavMenu.js
+++ b/src/view/layout/PrimaryNavMenu.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { NavLink } from "react-router-dom";
-import UsaButton from "../util/UsaButton";
 import close from "uswds/dist/img/close.svg";
 import "./PrimaryNavMenu.css";
 

--- a/src/view/layout/__test__/ErrorHandler.test.js
+++ b/src/view/layout/__test__/ErrorHandler.test.js
@@ -1,0 +1,73 @@
+import React from "react";
+import { mount } from "enzyme";
+import { ErrorHandler } from "../ErrorHandler";
+import { AuthContext } from "../../auth/AuthContainer";
+
+describe("ErrorHandler", () => {
+  const consoleError = console.error;
+
+  beforeEach(() => {
+    console.error = jest.fn();
+  });
+
+  afterEach(() => {
+    console.error = consoleError;
+  });
+
+  it("should set an access notification on 403 error", () => {
+    const setNotification = jest.fn();
+    const error = {
+      status: 403,
+      message: "Forbidden"
+    };
+    mount(<ErrorHandler setNotification={setNotification} error={error} />);
+    expect(setNotification).toBeCalledWith({
+      message: "You do not have access to this system.",
+      type: "error"
+    });
+  });
+  it("should set logged in to false on 401 error", () => {
+    const setNotification = jest.fn();
+    const setLoggedIn = jest.fn();
+    const error = {
+      status: 401,
+      message: "Unauthorized"
+    };
+    mount(
+      <AuthContext.Provider value={{ loggedIn: true, setLoggedIn }}>
+        <ErrorHandler setNotification={setNotification} error={error} />
+      </AuthContext.Provider>
+    );
+    expect(setLoggedIn).toBeCalledWith(false);
+  });
+  it("should console.error any other errors", () => {
+    const setNotification = jest.fn();
+    const setLoggedIn = jest.fn();
+    const error = {
+      status: 500,
+      message: "Server error"
+    };
+    mount(
+      <AuthContext.Provider value={{ loggedIn: true, setLoggedIn }}>
+        <ErrorHandler setNotification={setNotification} error={error} />
+      </AuthContext.Provider>
+    );
+    expect(console.error).toBeCalledWith({
+      message: "Server error",
+      status: 500
+    });
+  });
+  it("should not do anything if the error is malformed", () => {
+    const setNotification = jest.fn();
+    const setLoggedIn = jest.fn();
+    const error = {};
+    mount(
+      <AuthContext.Provider value={{ loggedIn: true, setLoggedIn }}>
+        <ErrorHandler setNotification={setNotification} error={error} />
+      </AuthContext.Provider>
+    );
+    expect(setLoggedIn).toBeCalledTimes(0);
+    expect(setNotification).toBeCalledTimes(0);
+    expect(console.error).toBeCalledTimes(0);
+  });
+});


### PR DESCRIPTION
## Proposed changes

This PR enables OAuth on the front-end. 

- Add `AuthContainer` that maintains a `loggedIn` state via context
- Add an `AuthForm` to be displayed if the user is not authenticated
- Add an `ErrorHandler` component
