### PR TITLE
Update Platform display logic with correct property name and type

### DIFF
--- a/src/controller/config.js
+++ b/src/controller/config.js
@@ -137,7 +137,7 @@ const I90_HEADERS = [
   {
     header: "Platform",
     field: "extraData",
-    content: d => (d.streamlinedProcess === true ? "SP" : "Legacy"),
+    content: d => (String(d.i90SP) === "true" ? "SP" : "Legacy"),
     views: [VIEWS.CASES_TO_WORK.TITLE, VIEWS.SNOOZED_CASES.TITLE]
   },
   {

--- a/src/stories/ReceiptList.stories.jsx
+++ b/src/stories/ReceiptList.stories.jsx
@@ -14,7 +14,7 @@ const sampleCases = [
       caseState: "Happy",
       caseSubstatus: "Printing",
       channelType: "Pigeon",
-      streamlinedProcess: false,
+      i90SP: "false",
       applicationReason: "Boredom"
     },
     previouslySnoozed: true
@@ -27,7 +27,7 @@ const sampleCases = [
       caseState: "Happy",
       caseSubstatus: "Amazingly Successful",
       channelType: "Semaphore",
-      streamlinedProcess: true,
+      i90SP: "true",
       applicationReason: "Enthusiasm"
     }
   }
@@ -108,7 +108,7 @@ storiesOf("ReceiptList", module)
         caseState: "Happy",
         caseSubstatus: "Amazingly Successful",
         channelType: "Semaphore",
-        streamlinedProcess: true,
+        i90SP: "true",
         applicationReason: "Enthusiasm"
       }
     });
@@ -125,6 +125,27 @@ storiesOf("ReceiptList", module)
           details: action("details clicked!")
         }}
         headers={getHeaders(modifiedHeaders, VIEWS.SNOOZED_CASES.TITLE)}
+        isLoading={false}
+      />
+    );
+  })
+  .add("Tabular Cases-to-Work List with some items; boolean SP", () => {
+    const modifiedSampleCases = sampleCases.map((sampleCase, i) => {
+      return {
+        ...sampleCase,
+        extraData: { ...sampleCases.extraData, i90SP: i % 2 === 1 }
+      };
+    });
+
+    return (
+      <ReceiptList
+        view={VIEWS.CASES_TO_WORK.TITLE}
+        cases={modifiedSampleCases}
+        callback={{
+          snoozeUpdate: action("show actions clicked!"),
+          details: action("details clicked!")
+        }}
+        headers={getHeaders(modifiedHeaders, VIEWS.CASES_TO_WORK.TITLE)}
         isLoading={false}
       />
     );

--- a/src/stories/__snapshots__/storyshots.test.js.snap
+++ b/src/stories/__snapshots__/storyshots.test.js.snap
@@ -721,6 +721,182 @@ exports[`Storyshots ReceiptList Tabular Cases-to-Work List with some items 1`] =
 </table>
 `;
 
+exports[`Storyshots ReceiptList Tabular Cases-to-Work List with some items; boolean SP 1`] = `
+<table
+  className="usa-table usa-table--borderless width-full"
+>
+  <thead>
+    <tr>
+      <th
+        className="min"
+      >
+        
+      </th>
+      <th>
+        Receipt Number
+      </th>
+      <th>
+        Application Reason
+      </th>
+      <th>
+        Case Status
+      </th>
+      <th>
+        Case Substatus
+      </th>
+      <th>
+        Platform
+      </th>
+      <th>
+        Assigned
+      </th>
+      <th>
+        Actions
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td
+        className="min"
+      >
+        <button
+          className="usa-button usa-button--none"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-plus fa-w-14 "
+            data-icon="plus"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            style={Object {}}
+            viewBox="0 0 448 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+        </button>
+      </td>
+      <td>
+        <a
+          href="FKE5381523"
+          target="_elis_viewer"
+        >
+          FKE5381523
+        </a>
+         
+        <svg
+          aria-hidden="true"
+          aria-label="Snooze expired - Please review case"
+          className="svg-inline--fa fa-exclamation-triangle fa-w-18 text-accent-warm"
+          data-icon="exclamation-triangle"
+          data-place="right"
+          data-prefix="fas"
+          data-tip={true}
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 576 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+        <div
+          className="__react_component_tooltip place-top type-dark "
+          data-id="tooltip"
+        >
+          Snooze expired - Please review case
+        </div>
+      </td>
+      <td />
+      <td />
+      <td />
+      <td>
+        Legacy
+      </td>
+      <td />
+      <td>
+        <button
+          className="usa-button usa-button--outline"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          Snooze
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td
+        className="min"
+      >
+        <button
+          className="usa-button usa-button--none"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-plus fa-w-14 "
+            data-icon="plus"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            style={Object {}}
+            viewBox="0 0 448 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+        </button>
+      </td>
+      <td>
+        <a
+          href="FKE8206743"
+          target="_elis_viewer"
+        >
+          FKE8206743
+        </a>
+      </td>
+      <td />
+      <td />
+      <td />
+      <td>
+        SP
+      </td>
+      <td />
+      <td>
+        <button
+          className="usa-button usa-button--outline"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          Snooze
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
 exports[`Storyshots ReceiptList Tabular Snoozed Case List with some items 1`] = `
 <table
   className="usa-table usa-table--borderless width-full"

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,7 @@ export interface Case {
       caseState: string;
       caseSubstatus: string;
       channelType: string;
-      streamlinedProcess: boolean;
+      i90SP: string | boolean;
       applicationReason: string;
     };
   };


### PR DESCRIPTION
This fixes issue #69 by:

- Changing `streamlinedProcess` to `i90SP`
- Coercing `i90SP` value to string, which should hopefully be more flexible with respect to type of data receive
- Adding a storybook snapshot test for both `string` and `boolean` `i90SP` data