### PR TITLE
Set CSRF token for PUT and DELETE endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.9.0",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "@types/enzyme": "^3.10.3",
+    "@types/fetch-mock": "^7.3.1",
     "@types/jest": "^24.0.17",
     "@types/node": "^12.7.2",
     "@types/react": "^16.9.2",
@@ -62,6 +63,7 @@
     "babel-plugin-macros": "^2.6.1",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
+    "fetch-mock": "^7.3.9",
     "prettier": "^1.18.2",
     "react-test-renderer": "^16.8.6",
     "require-context.macro": "^1.1.0"

--- a/src/model/CaseIssueAPIClient.ts
+++ b/src/model/CaseIssueAPIClient.ts
@@ -5,6 +5,7 @@ type SnoozeState = "active" | "snoozed";
 
 class CaseIssueAPIClient extends ClientBase {
   public async deleteActiveSnooze(receiptNumber: string) {
+    this.setCsrf();
     return await this.delete(
       CaseIssueAPIClient.createApiUrl(
         `/api/caseDetails/${this.caseManagementSystem}/${receiptNumber}/activeSnooze`
@@ -48,6 +49,7 @@ class CaseIssueAPIClient extends ClientBase {
     receiptNumber: string,
     snoozeInputs: SnoozeOption
   ) {
+    this.setCsrf();
     return await this.put(
       CaseIssueAPIClient.createApiUrl(
         `/api/caseDetails/${this.caseManagementSystem}/${receiptNumber}/activeSnooze`

--- a/src/model/ClientBase.ts
+++ b/src/model/ClientBase.ts
@@ -19,6 +19,25 @@ class ClientBase extends FetchClient {
   constructor() {
     super();
     this.credentials = "include";
+    this.setCsrf();
+  }
+
+  protected setCsrf() {
+    if (localStorage.csrf) {
+      const { headerName, token } = JSON.parse(localStorage.csrf);
+      this.defaultHeaders[headerName as keyof Headers] = token;
+    }
+  }
+
+  public async getCsrf() {
+    const response = await this.getAsJson(ClientBase.createApiUrl("/csrf"));
+    if (response.succeeded) {
+      const csrf = {
+        headerName: response.payload.headerName,
+        token: response.payload.token
+      };
+      localStorage.setItem("csrf", JSON.stringify(csrf));
+    }
   }
 }
 

--- a/src/model/__test__/ClientBase.test.ts
+++ b/src/model/__test__/ClientBase.test.ts
@@ -1,0 +1,38 @@
+import ClientBase from "../ClientBase";
+import fetchMock from "fetch-mock";
+import { API_BASE_URL } from "../../controller/config";
+
+const createApiUrl = (endpoint: string) => {
+  return API_BASE_URL + endpoint;
+};
+
+describe("ClientBase", () => {
+  beforeEach(() => {
+    fetchMock.restore();
+    localStorage.clear();
+  });
+  const fakeCsrf = {
+    headerName: "csrf-header",
+    token: "abcd"
+  };
+  it("should set a csrf token response to localStorage", () => {
+    const clientBase = new ClientBase();
+    fetchMock.mock(createApiUrl("/csrf"), fakeCsrf);
+    return clientBase
+      .getCsrf()
+      .then(() =>
+        expect(
+          JSON.parse(localStorage.getItem("csrf") as string)
+        ).toStrictEqual(fakeCsrf)
+      );
+  });
+  it("should not set a csrf token to localStorage if no csrf is returned from fetch", () => {
+    const clientBase = new ClientBase();
+    fetchMock.mock(createApiUrl("/csrf"), {});
+    return clientBase.getCsrf().then(() => {
+      const csrf = JSON.parse(localStorage.getItem("csrf") as string);
+      expect(csrf.headerName).toBe(undefined);
+      expect(csrf.token).toBe(undefined);
+    });
+  });
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,4 +1,9 @@
 import { configure } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
+import { browserMock } from "./testConfig/browserMock";
 
-configure({ adapter: new Adapter() });
+configure({
+  adapter: new Adapter()
+});
+
+browserMock();

--- a/src/testConfig/browserMock.js
+++ b/src/testConfig/browserMock.js
@@ -1,0 +1,21 @@
+export const browserMock = () => {
+  const localStorageMock = (() => {
+    var store = {};
+
+    return {
+      getItem: key => {
+        return store[key] || null;
+      },
+      setItem: (key, value) => {
+        store[key] = value.toString();
+      },
+      clear: () => {
+        store = {};
+      }
+    };
+  })();
+
+  Object.defineProperty(window, "localStorage", {
+    value: localStorageMock
+  });
+};

--- a/src/view/auth/AuthContainer.tsx
+++ b/src/view/auth/AuthContainer.tsx
@@ -24,6 +24,9 @@ const AuthContainer: React.FC<AuthContainerProps> = props => {
       return setName("");
     }
 
+    // Get csrf from server before it's needed
+    RestAPIClient.cases.getCsrf();
+
     const getUser = async () => {
       const response = await RestAPIClient.auth.getCurrentUser();
       if (response.succeeded) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2052,6 +2052,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/fetch-mock@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@types/fetch-mock/-/fetch-mock-7.3.1.tgz#df7421e8bcb351b430bfbfa5c52bb353826ac94f"
+  integrity sha512-2U4vZWHNbsbK7TRmizgr/pbKe0FKopcxu+hNDtIBDiM1wvrKRItybaYj7VQ6w/hZJStU/JxRiNi5ww4YDEvKbA==
+
 "@types/history@*":
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.2.tgz#0e670ea254d559241b6eeb3894f8754991e73220"
@@ -3181,6 +3186,15 @@ babel-plugin-transform-undefined-to-void@^6.9.4:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz#be241ca81404030678b748717322b89d0c8fe280"
   integrity sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=
 
+babel-polyfill@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  integrity sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
+
 babel-preset-jest@^24.6.0:
   version "24.6.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz#66f06136eefce87797539c0d63f1769cc3915984"
@@ -4213,6 +4227,11 @@ core-js@^2.4.0:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
   integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
+
+core-js@^2.5.0, core-js@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
+  integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
 
 core-js@^3.0.1, core-js@^3.0.4:
   version "3.1.4"
@@ -5759,6 +5778,17 @@ fbjs@^0.8.0, fbjs@^0.8.1:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
 
+fetch-mock@^7.3.9:
+  version "7.3.9"
+  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-7.3.9.tgz#a80fd2a1728f72e0634ef7a9734bc61200096487"
+  integrity sha512-PgsTbiQBNapFz2P2UwDl3gowK3nZqfV4HdyDZ1dI4eTGGH9MLAeBglIPbyDbbNQoGYBOfla6/9uaiq7az2z4Aw==
+  dependencies:
+    babel-polyfill "^6.26.0"
+    core-js "^2.6.9"
+    glob-to-regexp "^0.4.0"
+    path-to-regexp "^2.2.1"
+    whatwg-url "^6.5.0"
+
 figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
@@ -6213,6 +6243,11 @@ glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
+
+glob-to-regexp@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
+  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
 glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.1:
   version "7.1.4"
@@ -9567,6 +9602,11 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
+path-to-regexp@^2.2.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.4.0.tgz#35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704"
+  integrity sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -11290,6 +11330,11 @@ regenerator-runtime@0.13.2, regenerator-runtime@^0.13.2:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
   integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
+
+regenerator-runtime@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+  integrity sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"
@@ -13520,7 +13565,7 @@ whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
 
-whatwg-url@^6.4.1:
+whatwg-url@^6.4.1, whatwg-url@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
   integrity sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==


### PR DESCRIPTION
## Proposed change

- Retrieve CSRF token from `/csrf` endpoint after auth and persist it to `localStorage`
- Set CSRF token on `PUT` and `DELETE` requests
- Add some CSRF fetch client tests and supporting infrastructure (e.g., fetch and localStorage mocks). This should eventually be extended to other fetch functionality.