### PR TITLE
Add basic Matomo anaytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.1",
     "react-modal": "^3.9.1",
+    "react-piwik": "^1.6.0",
     "react-router-dom": "^5.0.1",
     "react-scripts": "3.0.1",
     "react-toastify": "^5.3.2",

--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import { VIEWS } from "./controller/config";
 import { Layout } from "./view/layout/Layout";
 import { AuthContainer } from "./view/auth/AuthContainer";
 import { Helmet } from "react-helmet";
+import { trackPageView, setDocumentTitle } from "./matomo-setup";
 
 library.add(fas);
 
@@ -22,7 +23,12 @@ const App = () => {
 
   return (
     <AuthContainer defaultLoggedInState={true}>
-      <Helmet>
+      <Helmet
+        onChangeClientState={({ title }) => {
+          setDocumentTitle(title);
+          trackPageView();
+        }}
+      >
         <title>{title}</title>
       </Helmet>
       <Layout

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,12 +2,12 @@ declare module "react-piwik";
 
 type MatomoEventCategory = "snooze";
 type MatomoEventAction = "createSnooze" | "reSnooze" | "deSnooze";
-type MatomoEventName = "snoozeReason";
-type MatomoEventValue = string | number;
+type MatomoEventName = string;
+type MatomoEventValue = number;
 
 type MatomoTrackEvent = (
   category: MatomoEventCategory,
   action: MatomoEventAction,
   name: MatomoEventName,
-  value: MatomoEventValue
+  value?: MatomoEventValue
 ) => void;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,13 @@
+declare module "react-piwik";
+
+type MatomoEventCategory = "snooze";
+type MatomoEventAction = "createSnooze" | "reSnooze" | "deSnooze";
+type MatomoEventName = "snoozeReason";
+type MatomoEventValue = string | number;
+
+type MatomoTrackEvent = (
+  category: MatomoEventCategory,
+  action: MatomoEventAction,
+  name: MatomoEventName,
+  value: MatomoEventValue
+) => void;

--- a/src/matomo-setup.js
+++ b/src/matomo-setup.js
@@ -1,0 +1,49 @@
+import ReactPiwik from "react-piwik";
+import { IS_TEST_ENV } from "./controller/config";
+
+const matomo = new ReactPiwik({
+  url: process.env.REACT_APP_MATOMO_URL,
+  siteId: process.env.REACT_APP_MATOMO_SITE_ID,
+  trackErrors: true
+});
+
+// Force Matomo to track a new visit on initial page view only
+//   "new_visit — If set to 1, will force a new visit to be created for this action"
+ReactPiwik.push(["appendToTrackingUrl", "new_visit=1"]);
+ReactPiwik.push(["trackPageView"]);
+
+// Immediately unset new_visit so subsequent actions/events continue in current visit
+ReactPiwik.push(["appendToTrackingUrl", "new_visit=0"]);
+
+// Enable periodic heartbeat requests to track time spent per page more precisely
+ReactPiwik.push(["enableHeartBeatTimer"]);
+
+// Enable JS error tracking
+ReactPiwik.push(["enableJSErrorTracking"]);
+
+const trackEvent = (category, action, name, value) => {
+  // Don't track events during tests since Matomo isn't initialized
+  if (!IS_TEST_ENV) {
+    ReactPiwik.push(["trackEvent", category, action, name, value]);
+  }
+};
+
+const trackPageView = () => {
+  ReactPiwik.push(["trackPageView"]);
+};
+
+const setDocumentTitle = title => {
+  ReactPiwik.push(["setDocumentTitle", title]);
+};
+
+const forceNewVisit = () => {
+  // Force Matomo to track a new visit on initial page view only
+  //   "new_visit — If set to 1, will force a new visit to be created for this action"
+  ReactPiwik.push(["appendToTrackingUrl", "new_visit=1"]);
+  trackPageView();
+
+  // Immediately unset new_visit so subsequent actions/events continue in current visit
+  ReactPiwik.push(["appendToTrackingUrl", "new_visit=0"]);
+};
+
+export { forceNewVisit, matomo, setDocumentTitle, trackEvent, trackPageView };

--- a/src/matomo-setup.js
+++ b/src/matomo-setup.js
@@ -1,11 +1,15 @@
-import ReactPiwik from "react-piwik";
+import Piwik from "react-piwik";
 import { IS_TEST_ENV } from "./controller/config";
 
-const matomo = new ReactPiwik({
-  url: process.env.REACT_APP_MATOMO_URL,
-  siteId: process.env.REACT_APP_MATOMO_SITE_ID,
-  trackErrors: true
-});
+const matomo =
+  !IS_TEST_ENV &&
+  new Piwik({
+    url: process.env.REACT_APP_MATOMO_URL,
+    siteId: process.env.REACT_APP_MATOMO_SITE_ID,
+    trackErrors: true
+  });
+
+const ReactPiwik = IS_TEST_ENV ? [] : Piwik;
 
 // Force Matomo to track a new visit on initial page view only
 //   "new_visit — If set to 1, will force a new visit to be created for this action"

--- a/src/matomo-setup.ts
+++ b/src/matomo-setup.ts
@@ -25,7 +25,7 @@ ReactPiwik.push(["enableHeartBeatTimer"]);
 // Enable JS error tracking
 ReactPiwik.push(["enableJSErrorTracking"]);
 
-const trackEvent = (category, action, name, value) => {
+const trackEvent: MatomoTrackEvent = (category, action, name, value) => {
   // Don't track events during tests since Matomo isn't initialized
   if (!IS_TEST_ENV) {
     ReactPiwik.push(["trackEvent", category, action, name, value]);
@@ -36,7 +36,7 @@ const trackPageView = () => {
   ReactPiwik.push(["trackPageView"]);
 };
 
-const setDocumentTitle = title => {
+const setDocumentTitle = (title: string) => {
   ReactPiwik.push(["setDocumentTitle", title]);
 };
 

--- a/src/view/caselists/ActiveCaseList.jsx
+++ b/src/view/caselists/ActiveCaseList.jsx
@@ -7,6 +7,7 @@ import SnoozeForm from "../../controller/SnoozeForm";
 import { formatNotes } from "../util/formatNotes";
 import RestAPIClient from "../../model/RestAPIClient";
 import { DesnoozedWarning } from "../notifications/DesnoozedWarning";
+import { trackEvent } from "../../matomo-setup";
 
 const ActiveCaseList = props => {
   const [cases, setCases] = useState([]);
@@ -66,6 +67,7 @@ const ActiveCaseList = props => {
         }.`,
         type: "success"
       });
+      trackEvent("snooze", "createSnooze", snoozeOption.snoozeReason);
       return setCases(
         cases.filter(c => c.receiptNumber !== rowData.receiptNumber)
       );

--- a/src/view/caselists/SnoozedCaseList.jsx
+++ b/src/view/caselists/SnoozedCaseList.jsx
@@ -114,6 +114,7 @@ const SnoozedCaseList = props => {
           snoozedCase => snoozedCase.receiptNumber !== rowData.receiptNumber
         )
       );
+      trackEvent("snooze", "deSnooze", "desnoozed");
       return setNotification({
         message: `${rowData.receiptNumber} has been Unsnoozed.`,
         type: "info"

--- a/src/view/caselists/SnoozedCaseList.jsx
+++ b/src/view/caselists/SnoozedCaseList.jsx
@@ -6,6 +6,7 @@ import { getHeaders } from "../util/getHeaders";
 import { CaseList } from "./CaseList";
 import { formatNotes } from "../util/formatNotes";
 import RestAPIClient from "../../model/RestAPIClient";
+import { trackEvent } from "../../matomo-setup";
 
 const SnoozedCaseList = props => {
   const [cases, setCases] = useState([]);
@@ -62,6 +63,7 @@ const SnoozedCaseList = props => {
         }.`,
         type: "success"
       });
+      trackEvent("snooze", "reSnooze", snoozeOption.snoozeReason);
       const snoozedCases = cases
         .map(snoozedCase => {
           if (snoozedCase.receiptNumber === rowData.receiptNumber) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10924,6 +10924,11 @@ react-modal@^3.9.1:
     react-lifecycles-compat "^3.0.0"
     warning "^4.0.3"
 
+react-piwik@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/react-piwik/-/react-piwik-1.6.0.tgz#3b9eee55167d953824867791cd5288593d652d66"
+  integrity sha512-ANK/SDDA3z827vcY8w77tTC8pOkpMSw1xNs5ifImho92oNS1rIfiTdVXNW7TpqP3a8hU+p9AxPAgPZhmkYtyzw==
+
 react-popper-tooltip@^2.8.3:
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/react-popper-tooltip/-/react-popper-tooltip-2.8.3.tgz#1c63e7473a96362bd93be6c94fa404470a265197"


### PR DESCRIPTION
## Proposed changes

- Add `react-piwik`
- Add `matomo-setup.ts` file, which initializes matomo and creates tracking functions to be used across the app
- Add `index.d.ts` type declaration file with Matomo-related types (The type declarations in `types.ts` should eventually move into this file)
- Add the following event tracking:
  - Page view
  - Snooze, DeSnooze, ReSnooze