### PR TITLE
Add ts and tsx files to code coverage reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "jest": {
     "collectCoverageFrom": [
-      "src/**/*.{js,jsx}",
+      "src/**/*.{js,jsx,ts,tsx}",
       "!src/stories/**"
     ]
   },


### PR DESCRIPTION
## Proposed change

This PR adds `ts` and `tsx` files to the `package.json` `collectCoverageFrom` object.