### PR TITLE
Adds redux for ActiveCaseList and SnoozedCaseList

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import "./App.css";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { fas } from "@fortawesome/free-solid-svg-icons";
 import ActiveCaseList from "./view/caselists/ActiveCaseList";
-import { SnoozedCaseList } from "./view/caselists/SnoozedCaseList";
+import SnoozedCaseList from "./view/caselists/SnoozedCaseList";
 import { VIEWS } from "./controller/config";
 import { Layout } from "./view/layout/Layout";
 import { AuthContainer } from "./view/auth/AuthContainer";
@@ -15,6 +15,7 @@ import { RootState } from "./redux/create";
 import { Dispatch, bindActionCreators, AnyAction } from "redux";
 import { appStatusActionCreators } from "./redux/modules/appStatus";
 import { connect } from "react-redux";
+import { casesActionCreators } from "./redux/modules/cases";
 
 library.add(fas);
 
@@ -25,7 +26,8 @@ const mapStateToProps = (state: RootState) => ({
 const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) =>
   bindActionCreators(
     {
-      setPageTitle: appStatusActionCreators.setPageTitle
+      setPageTitle: appStatusActionCreators.setPageTitle,
+      clearCases: casesActionCreators.clearCases
     },
     dispatch
   );
@@ -35,12 +37,14 @@ type AppProps = ReturnType<typeof mapStateToProps> &
 
 export const UnconnectedApp: React.FC<AppProps> = ({
   setPageTitle,
-  pageTitle
+  pageTitle,
+  clearCases
 }) => {
-  const setSubtitle = (subtitle: string) => {
+  const setSubtitleAndClearCases = (subtitle: string) => {
     const newPageTitle = `${subtitle} | Case Issue Navigator`;
     if (newPageTitle !== pageTitle) {
       setPageTitle(newPageTitle);
+      clearCases();
     }
   };
 
@@ -61,7 +65,7 @@ export const UnconnectedApp: React.FC<AppProps> = ({
               path="/"
               exact={true}
               render={() => {
-                setSubtitle(VIEWS.CASES_TO_WORK.TITLE);
+                setSubtitleAndClearCases(VIEWS.CASES_TO_WORK.TITLE);
                 return (
                   <ActiveCaseList
                     updateSummaryData={updateSummaryData}
@@ -75,7 +79,7 @@ export const UnconnectedApp: React.FC<AppProps> = ({
             <Route
               path={`/${VIEWS.SNOOZED_CASES.ROUTE}`}
               render={() => {
-                setSubtitle(VIEWS.SNOOZED_CASES.TITLE);
+                setSubtitleAndClearCases(VIEWS.SNOOZED_CASES.TITLE);
                 return (
                   <SnoozedCaseList
                     updateSummaryData={updateSummaryData}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import "uswds";
 import "./App.css";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { fas } from "@fortawesome/free-solid-svg-icons";
-import { ActiveCaseList } from "./view/caselists/ActiveCaseList";
+import ActiveCaseList from "./view/caselists/ActiveCaseList";
 import { SnoozedCaseList } from "./view/caselists/SnoozedCaseList";
 import { VIEWS } from "./controller/config";
 import { Layout } from "./view/layout/Layout";

--- a/src/__test__/App.test.tsx
+++ b/src/__test__/App.test.tsx
@@ -15,6 +15,7 @@ describe("App", () => {
           <UnconnectedApp
             pageTitle="Cases to Work | Case Issue Navigator"
             setPageTitle={jest.fn()}
+            clearCases={jest.fn()}
           />
         </Provider>
       </MemoryRouter>
@@ -30,6 +31,7 @@ describe("App", () => {
           <UnconnectedApp
             pageTitle="Case Issue Navigator"
             setPageTitle={setPageTitle}
+            clearCases={jest.fn()}
           />
         </Provider>
       </MemoryRouter>

--- a/src/__test__/App.test.tsx
+++ b/src/__test__/App.test.tsx
@@ -1,30 +1,22 @@
 import React from "react";
-import { shallow, mount } from "enzyme";
+import { mount } from "enzyme";
 import App, { UnconnectedApp } from "../App";
 import { MemoryRouter } from "react-router";
 import { Helmet } from "react-helmet";
 import { VIEWS } from "../controller/config";
-import { createStore } from "redux";
-import { rootReducer } from "../redux/create";
+import { store } from "../redux/create";
 import { Provider } from "react-redux";
 
 describe("App", () => {
-  it("should initially render with the correct title", () => {
-    const wrapper = shallow(
-      <UnconnectedApp
-        pageTitle="Case Issue Navigator"
-        setPageTitle={jest.fn()}
-      />
-    );
-    expect(wrapper.find("title").text()).toEqual("Case Issue Navigator");
-  });
   it("should show the correct title for Cases to Work", () => {
     mount(
       <MemoryRouter initialEntries={["/"]}>
-        <UnconnectedApp
-          pageTitle="Cases to Work | Case Issue Navigator"
-          setPageTitle={jest.fn()}
-        />
+        <Provider store={store}>
+          <UnconnectedApp
+            pageTitle="Cases to Work | Case Issue Navigator"
+            setPageTitle={jest.fn()}
+          />
+        </Provider>
       </MemoryRouter>
     );
     const helmet = Helmet.peek();
@@ -34,10 +26,12 @@ describe("App", () => {
     const setPageTitle = jest.fn();
     mount(
       <MemoryRouter initialEntries={["/snoozed-cases"]}>
-        <UnconnectedApp
-          pageTitle="Case Issue Navigator"
-          setPageTitle={setPageTitle}
-        />
+        <Provider store={store}>
+          <UnconnectedApp
+            pageTitle="Case Issue Navigator"
+            setPageTitle={setPageTitle}
+          />
+        </Provider>
       </MemoryRouter>
     );
     expect(setPageTitle).toHaveBeenCalledWith(
@@ -45,7 +39,6 @@ describe("App", () => {
     );
   });
   it("should connect to the store", () => {
-    const store = createStore(rootReducer);
     mount(
       <MemoryRouter initialEntries={["/snoozed-cases"]}>
         <Provider store={store}>

--- a/src/redux/create.ts
+++ b/src/redux/create.ts
@@ -1,9 +1,11 @@
 import { combineReducers, createStore, applyMiddleware, compose } from "redux";
 import thunk from "redux-thunk";
 import appStatusReducer, { AppStatusAction } from "./modules/appStatus";
+import casesReducer, { CasesAction } from "./modules/cases";
 
 export const rootReducer = combineReducers({
-  appStatus: appStatusReducer
+  appStatus: appStatusReducer,
+  cases: casesReducer
 });
 
 export const store = createStore(
@@ -16,6 +18,6 @@ export const store = createStore(
   )
 );
 
-export type RootAction = AppStatusAction;
+export type RootAction = AppStatusAction | CasesAction;
 export type Store = typeof store;
 export type RootState = ReturnType<typeof rootReducer>;

--- a/src/redux/modules/__test__/cases.test.ts
+++ b/src/redux/modules/__test__/cases.test.ts
@@ -2,77 +2,67 @@ import { createStore } from "redux";
 import { rootReducer, Store } from "../../create";
 import { casesActionCreators } from "../cases";
 
+const initialCases: Case[] = [
+  {
+    receiptNumber: "ABC123",
+    caseCreation: "Dec 12, 1984",
+    extraData: {
+      caseStatus: "",
+      caseState: "",
+      caseSubstatus: "",
+      channelType: "",
+      i90SP: true,
+      applicationReason: "some reason",
+      caseAge: "94 days",
+      caseId: "ABC123"
+    },
+    previouslySnoozed: false,
+    showDetails: false
+  }
+];
+const newCases: Case[] = [
+  {
+    receiptNumber: "DEF567",
+    caseCreation: "Dec 12, 1984",
+    extraData: {
+      caseStatus: "",
+      caseState: "",
+      caseSubstatus: "",
+      channelType: "",
+      i90SP: true,
+      applicationReason: "some reason",
+      caseAge: "94 days",
+      caseId: "DEF567"
+    },
+    previouslySnoozed: false,
+    showDetails: false
+  }
+];
+
 describe("redux - cases", () => {
   let testStore: Store;
-  const { addCases } = casesActionCreators;
+  const { addCases, setCases } = casesActionCreators;
   beforeEach(() => {
     testStore = createStore(rootReducer);
   });
   it("adds a case to an empty case list", () => {
-    const cases: Case[] = [
-      {
-        receiptNumber: "ABC123",
-        caseCreation: "Dec 12, 1984",
-        extraData: {
-          caseStatus: "",
-          caseState: "",
-          caseSubstatus: "",
-          channelType: "",
-          i90SP: true,
-          applicationReason: "some reason",
-          caseAge: "94 days",
-          caseId: "ABC123"
-        },
-        previouslySnoozed: false,
-        showDetails: false
-      }
-    ];
     const { dispatch } = testStore;
-    dispatch(addCases(cases));
-    expect(testStore.getState().cases.caselist).toEqual(cases);
+    dispatch(addCases(initialCases));
+    expect(testStore.getState().cases.caselist).toEqual(initialCases);
   });
   it("adds a case to a non-empty case list", () => {
-    const initialCases: Case[] = [
-      {
-        receiptNumber: "ABC123",
-        caseCreation: "Dec 12, 1984",
-        extraData: {
-          caseStatus: "",
-          caseState: "",
-          caseSubstatus: "",
-          channelType: "",
-          i90SP: true,
-          applicationReason: "some reason",
-          caseAge: "94 days",
-          caseId: "ABC123"
-        },
-        previouslySnoozed: false,
-        showDetails: false
-      }
-    ];
-    const newCases: Case[] = [
-      {
-        receiptNumber: "DEF567",
-        caseCreation: "Dec 12, 1984",
-        extraData: {
-          caseStatus: "",
-          caseState: "",
-          caseSubstatus: "",
-          channelType: "",
-          i90SP: true,
-          applicationReason: "some reason",
-          caseAge: "94 days",
-          caseId: "DEF567"
-        },
-        previouslySnoozed: false,
-        showDetails: false
-      }
-    ];
     const { dispatch } = testStore;
     dispatch(addCases(initialCases));
     dispatch(addCases(newCases));
     expect(testStore.getState().cases.caselist).toEqual(
       initialCases.concat(newCases)
     );
+  });
+  it("sets cases, replacing previous cases", () => {
+    const { dispatch } = testStore;
+    dispatch(setCases(initialCases));
+    expect(testStore.getState().cases.caselist).toEqual(initialCases);
+    dispatch(setCases(newCases));
+    expect(testStore.getState().cases.caselist).toEqual(newCases);
   });
 });

--- a/src/redux/modules/__test__/cases.test.ts
+++ b/src/redux/modules/__test__/cases.test.ts
@@ -1,0 +1,78 @@
+import { createStore } from "redux";
+import { rootReducer, Store } from "../../create";
+import { casesActionCreators } from "../cases";
+
+describe("redux - cases", () => {
+  let testStore: Store;
+  const { addCases } = casesActionCreators;
+  beforeEach(() => {
+    testStore = createStore(rootReducer);
+  });
+  it("adds a case to an empty case list", () => {
+    const cases: Case[] = [
+      {
+        receiptNumber: "ABC123",
+        caseCreation: "Dec 12, 1984",
+        extraData: {
+          caseStatus: "",
+          caseState: "",
+          caseSubstatus: "",
+          channelType: "",
+          i90SP: true,
+          applicationReason: "some reason",
+          caseAge: "94 days",
+          caseId: "ABC123"
+        },
+        previouslySnoozed: false,
+        showDetails: false
+      }
+    ];
+    const { dispatch } = testStore;
+    dispatch(addCases(cases));
+    expect(testStore.getState().cases.caselist).toEqual(cases);
+  });
+  it("adds a case to a non-empty case list", () => {
+    const initialCases: Case[] = [
+      {
+        receiptNumber: "ABC123",
+        caseCreation: "Dec 12, 1984",
+        extraData: {
+          caseStatus: "",
+          caseState: "",
+          caseSubstatus: "",
+          channelType: "",
+          i90SP: true,
+          applicationReason: "some reason",
+          caseAge: "94 days",
+          caseId: "ABC123"
+        },
+        previouslySnoozed: false,
+        showDetails: false
+      }
+    ];
+    const newCases: Case[] = [
+      {
+        receiptNumber: "DEF567",
+        caseCreation: "Dec 12, 1984",
+        extraData: {
+          caseStatus: "",
+          caseState: "",
+          caseSubstatus: "",
+          channelType: "",
+          i90SP: true,
+          applicationReason: "some reason",
+          caseAge: "94 days",
+          caseId: "DEF567"
+        },
+        previouslySnoozed: false,
+        showDetails: false
+      }
+    ];
+    const { dispatch } = testStore;
+    dispatch(addCases(initialCases));
+    dispatch(addCases(newCases));
+    expect(testStore.getState().cases.caselist).toEqual(
+      initialCases.concat(newCases)
+    );
+  });
+});

--- a/src/redux/modules/__test__/cases.test.ts
+++ b/src/redux/modules/__test__/cases.test.ts
@@ -121,7 +121,7 @@ describe("redux - cases", () => {
       })
     );
     const { dispatch } = testAsyncStore;
-    await loadCases()(dispatch);
+    await loadCases("active")(dispatch);
     expect(dispatch).toHaveBeenCalledWith(addCases(initialCases));
   });
 });

--- a/src/redux/modules/__test__/cases.test.ts
+++ b/src/redux/modules/__test__/cases.test.ts
@@ -1,6 +1,6 @@
 import { createStore } from "redux";
-import { rootReducer, Store } from "../../create";
-import { casesActionCreators } from "../cases";
+import { rootReducer, Store, store } from "../../create";
+import { casesActionCreators, loadCases } from "../cases";
 
 const initialCases: Case[] = [
   {
@@ -41,7 +41,15 @@ const newCases: Case[] = [
 
 describe("redux - cases", () => {
   let testStore: Store;
-  const { addCases, setCases } = casesActionCreators;
+  const {
+    addCases,
+    setCases,
+    removeCase,
+    clearCases,
+    setCaseType,
+    toggleDetails,
+    setIsLoading
+  } = casesActionCreators;
   beforeEach(() => {
     testStore = createStore(rootReducer);
   });
@@ -64,5 +72,56 @@ describe("redux - cases", () => {
     expect(testStore.getState().cases.caselist).toEqual(initialCases);
     dispatch(setCases(newCases));
     expect(testStore.getState().cases.caselist).toEqual(newCases);
+  });
+  it("removes a case", () => {
+    const { dispatch } = testStore;
+    dispatch(setCases(initialCases));
+    dispatch(removeCase("ABC123"));
+    expect(testStore.getState().cases.caselist).toEqual([]);
+  });
+  it("clears all cases", () => {
+    const { dispatch } = testStore;
+    dispatch(setCases(initialCases));
+    dispatch(addCases(newCases));
+    dispatch(clearCases());
+    expect(testStore.getState().cases.caselist).toEqual([]);
+  });
+  it("sets the case type", () => {
+    const { dispatch } = testStore;
+    dispatch(setCaseType("snoozed"));
+    expect(testStore.getState().cases.type).toBe("snoozed");
+  });
+  it("toggles case details", () => {
+    const { dispatch } = testStore;
+    dispatch(setCases(initialCases));
+    dispatch(addCases(newCases));
+    dispatch(toggleDetails("ABC123"));
+    const expected = [...initialCases, ...newCases].map(c => {
+      if (c.receiptNumber === "ABC123") {
+        c.showDetails = !c.showDetails;
+      }
+      return c;
+    });
+    expect(testStore.getState().cases.caselist).toEqual(expected);
+  });
+  it("sets cases loading state", () => {
+    const { dispatch } = testStore;
+    dispatch(setIsLoading(true));
+    expect(testStore.getState().cases.isLoading).toBe(true);
+    dispatch(setIsLoading(false));
+    expect(testStore.getState().cases.isLoading).toBe(false);
+  });
+  it("asynchronously loads cases", async () => {
+    const testAsyncStore = store;
+    jest.spyOn(testAsyncStore, "dispatch");
+    jest.spyOn(global as any, "fetch").mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => initialCases
+      })
+    );
+    const { dispatch } = testAsyncStore;
+    await loadCases()(dispatch);
+    expect(dispatch).toHaveBeenCalledWith(addCases(initialCases));
   });
 });

--- a/src/redux/modules/cases.ts
+++ b/src/redux/modules/cases.ts
@@ -1,0 +1,40 @@
+import { action } from "typesafe-actions";
+import { RootAction } from "../create";
+
+// Actions
+enum CasesActionType {
+  ADD_CASES = "cases/ADD_CASES"
+}
+
+export const casesActionCreators = {
+  addCases: (cases: Case[]) => action(CasesActionType.ADD_CASES, cases)
+};
+
+type ActionCreator = typeof casesActionCreators;
+
+export type CasesAction = ReturnType<ActionCreator[keyof ActionCreator]>;
+
+// Initial state
+export type CasesState = {
+  caselist: Case[];
+};
+
+export const initialState: CasesState = {
+  caselist: []
+};
+
+// Reducer
+export default function reducer(
+  state = initialState,
+  action: RootAction
+): CasesState {
+  switch (action.type) {
+    case CasesActionType.ADD_CASES:
+      return {
+        ...state,
+        caselist: [...state.caselist].concat(action.payload)
+      };
+    default:
+      return state;
+  }
+}

--- a/src/redux/modules/cases.ts
+++ b/src/redux/modules/cases.ts
@@ -17,12 +17,16 @@ export const casesActionCreators = {
     action("cases/SET_IS_LOADING", isLoading)
 };
 
-export const loadCases = (lastReceiptNumber?: string) => async (
-  dispatch: Dispatch<AnyAction>
-) => {
+export const loadCases = (
+  type: SnoozeState,
+  lastReceiptNumber?: string
+) => async (dispatch: Dispatch<AnyAction>) => {
   const { setIsLoading, addCases } = casesActionCreators;
   dispatch(setIsLoading(true));
-  const response = await RestAPIClient.cases.getActive(lastReceiptNumber);
+  const response =
+    type === "active"
+      ? await RestAPIClient.cases.getActive(lastReceiptNumber)
+      : await RestAPIClient.cases.getSnoozed(lastReceiptNumber);
   dispatch(setIsLoading(false));
 
   if (response.succeeded) {

--- a/src/redux/modules/cases.ts
+++ b/src/redux/modules/cases.ts
@@ -68,7 +68,7 @@ export default function reducer(
     case "cases/ADD_CASES":
       return {
         ...state,
-        caselist: [...state.caselist].concat(action.payload)
+        caselist: state.caselist.concat(action.payload)
       };
     case "cases/SET_CASES":
       return {

--- a/src/redux/modules/cases.ts
+++ b/src/redux/modules/cases.ts
@@ -1,6 +1,6 @@
 import { action } from "typesafe-actions";
 import { RootAction } from "../create";
-import { Dispatch } from "redux";
+import { Dispatch, AnyAction } from "redux";
 import RestAPIClient from "../../api/RestAPIClient";
 
 // Actions
@@ -18,7 +18,7 @@ export const casesActionCreators = {
 };
 
 export const loadCases = (lastReceiptNumber?: string) => async (
-  dispatch: Dispatch<RootAction>
+  dispatch: Dispatch<AnyAction>
 ) => {
   const { setIsLoading, addCases } = casesActionCreators;
   dispatch(setIsLoading(true));

--- a/src/redux/modules/cases.ts
+++ b/src/redux/modules/cases.ts
@@ -1,13 +1,41 @@
 import { action } from "typesafe-actions";
 import { RootAction } from "../create";
+import { Dispatch } from "redux";
+import RestAPIClient from "../../api/RestAPIClient";
 
 // Actions
-enum CasesActionType {
-  ADD_CASES = "cases/ADD_CASES"
-}
-
 export const casesActionCreators = {
-  addCases: (cases: Case[]) => action(CasesActionType.ADD_CASES, cases)
+  addCases: (cases: Case[]) => action("cases/ADD_CASES", cases),
+  setCases: (cases: Case[]) => action("cases/SET_CASES", cases),
+  removeCase: (receiptNumber: string) =>
+    action("cases/REMOVE_CASE", receiptNumber),
+  clearCases: () => action("cases/CLEAR_CASES"),
+  toggleDetails: (receiptNumber: string) =>
+    action("cases/TOGGLE_DETAILS", receiptNumber),
+  setCaseType: (type: SnoozeState) => action("cases/SET_CASE_TYPE", type),
+  setIsLoading: (isLoading: boolean) =>
+    action("cases/SET_IS_LOADING", isLoading)
+};
+
+export const loadCases = (lastReceiptNumber?: string) => async (
+  dispatch: Dispatch<RootAction>
+) => {
+  const { setIsLoading, addCases } = casesActionCreators;
+  dispatch(setIsLoading(true));
+  const response = await RestAPIClient.cases.getActive(lastReceiptNumber);
+  dispatch(setIsLoading(false));
+
+  if (response.succeeded) {
+    dispatch(addCases(response.payload));
+    return;
+  }
+
+  if (response.responseReceived) {
+    const errorJson = await response.responseError.getJson();
+    console.error(errorJson);
+  } else {
+    console.error(response);
+  }
 };
 
 type ActionCreator = typeof casesActionCreators;
@@ -17,10 +45,14 @@ export type CasesAction = ReturnType<ActionCreator[keyof ActionCreator]>;
 // Initial state
 export type CasesState = {
   caselist: Case[];
+  type: SnoozeState;
+  isLoading: boolean;
 };
 
 export const initialState: CasesState = {
-  caselist: []
+  caselist: [],
+  type: "active",
+  isLoading: false
 };
 
 // Reducer
@@ -29,10 +61,48 @@ export default function reducer(
   action: RootAction
 ): CasesState {
   switch (action.type) {
-    case CasesActionType.ADD_CASES:
+    case "cases/ADD_CASES":
       return {
         ...state,
         caselist: [...state.caselist].concat(action.payload)
+      };
+    case "cases/SET_CASES":
+      return {
+        ...state,
+        caselist: action.payload
+      };
+    case "cases/REMOVE_CASE":
+      return {
+        ...state,
+        caselist: state.caselist.filter(c => c.receiptNumber !== action.payload)
+      };
+    case "cases/CLEAR_CASES":
+      return {
+        ...state,
+        caselist: []
+      };
+    case "cases/SET_CASE_TYPE":
+      return {
+        ...state,
+        type: action.payload
+      };
+    case "cases/TOGGLE_DETAILS":
+      return {
+        ...state,
+        caselist: state.caselist.map(c => {
+          if (c.receiptNumber === action.payload) {
+            return {
+              ...c,
+              showDetails: !c.showDetails
+            };
+          }
+          return c;
+        })
+      };
+    case "cases/SET_IS_LOADING":
+      return {
+        ...state,
+        isLoading: action.payload
       };
     default:
       return state;

--- a/src/view/caselists/ActiveCaseList.tsx
+++ b/src/view/caselists/ActiveCaseList.tsx
@@ -15,7 +15,6 @@ const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) =>
   bindActionCreators(
     {
       removeCase: casesActionCreators.removeCase,
-      clearCases: casesActionCreators.clearCases,
       toggleDetails: casesActionCreators.toggleDetails,
       setCaseType: casesActionCreators.setCaseType,
       loadCases: loadCases
@@ -38,7 +37,6 @@ const UnconnectedActiveCaseList = (props: Props) => {
     summary,
     removeCase,
     caselist,
-    clearCases,
     toggleDetails,
     setCaseType,
     isLoading,
@@ -46,17 +44,16 @@ const UnconnectedActiveCaseList = (props: Props) => {
   } = props;
 
   useEffect(() => {
-    clearCases();
     setCaseType("active");
-    loadCases();
-  }, []);
+    loadCases("active");
+  }, [setCaseType, loadCases]);
 
   const loadMoreCases = () => {
     const receiptNumber =
       caselist.length > 0
         ? caselist[caselist.length - 1].receiptNumber
         : undefined;
-    loadCases(receiptNumber);
+    loadCases("active", receiptNumber);
   };
 
   return (

--- a/src/view/caselists/ActiveCaseList.tsx
+++ b/src/view/caselists/ActiveCaseList.tsx
@@ -14,13 +14,10 @@ const mapStateToProps = (state: RootState) => ({
 const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) =>
   bindActionCreators(
     {
-      addCases: casesActionCreators.addCases,
-      setCases: casesActionCreators.setCases,
       removeCase: casesActionCreators.removeCase,
       clearCases: casesActionCreators.clearCases,
       toggleDetails: casesActionCreators.toggleDetails,
       setCaseType: casesActionCreators.setCaseType,
-      setIsLoading: casesActionCreators.setIsLoading,
       loadCases: loadCases
     },
     dispatch

--- a/src/view/caselists/ActiveCaseList.tsx
+++ b/src/view/caselists/ActiveCaseList.tsx
@@ -1,61 +1,65 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect } from "react";
 import { CaseList } from "./CaseList";
-import RestAPIClient from "../../api/RestAPIClient";
 import { DesnoozedWarning } from "../notifications/DesnoozedWarning";
+import { RootState } from "../../redux/create";
+import { Dispatch, AnyAction, bindActionCreators } from "redux";
+import { casesActionCreators, loadCases } from "../../redux/modules/cases";
+import { connect } from "react-redux";
 
-interface Props {
+const mapStateToProps = (state: RootState) => ({
+  caselist: state.cases.caselist,
+  isLoading: state.cases.isLoading
+});
+
+const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) =>
+  bindActionCreators(
+    {
+      addCases: casesActionCreators.addCases,
+      setCases: casesActionCreators.setCases,
+      removeCase: casesActionCreators.removeCase,
+      clearCases: casesActionCreators.clearCases,
+      toggleDetails: casesActionCreators.toggleDetails,
+      setCaseType: casesActionCreators.setCaseType,
+      setIsLoading: casesActionCreators.setIsLoading,
+      loadCases: loadCases
+    },
+    dispatch
+  );
+
+type Props = {
   updateSummaryData: () => void;
   setError: React.Dispatch<APIError>;
   setNotification: React.Dispatch<React.SetStateAction<AppNotification>>;
   summary: Summary;
-}
+} & ReturnType<typeof mapStateToProps> &
+  ReturnType<typeof mapDispatchToProps>;
 
-const ActiveCaseList = (props: Props) => {
-  const [cases, setCases] = useState<Case[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-
-  const { setNotification, setError, summary } = props;
+const UnconnectedActiveCaseList = (props: Props) => {
+  const {
+    setNotification,
+    setError,
+    summary,
+    removeCase,
+    caselist,
+    clearCases,
+    toggleDetails,
+    setCaseType,
+    isLoading,
+    loadCases
+  } = props;
 
   useEffect(() => {
-    loadMoreCases();
+    clearCases();
+    setCaseType("active");
+    loadCases();
   }, []);
 
-  const removeCase = (receiptNumber: string) => {
-    setCases(cases.filter(c => c.receiptNumber !== receiptNumber));
-  };
-
-  const toggleDetails = (receiptNumber: string) => {
-    setCases(cases =>
-      cases.map(caseInformation => {
-        if (caseInformation.receiptNumber === receiptNumber) {
-          return {
-            ...caseInformation,
-            showDetails: !caseInformation.showDetails
-          };
-        }
-        return caseInformation;
-      })
-    );
-  };
-
-  const loadMoreCases = async () => {
-    setIsLoading(true);
+  const loadMoreCases = () => {
     const receiptNumber =
-      cases.length > 0 ? cases[cases.length - 1].receiptNumber : undefined;
-    const response = await RestAPIClient.cases.getActive(receiptNumber);
-    setIsLoading(false);
-
-    if (response.succeeded) {
-      setCases(previousCases => [...previousCases, ...response.payload]);
-      return;
-    }
-
-    if (response.responseReceived) {
-      const errorJson = await response.responseError.getJson();
-      setError(errorJson);
-    } else {
-      console.error(response);
-    }
+      caselist.length > 0
+        ? caselist[caselist.length - 1].receiptNumber
+        : undefined;
+    loadCases(receiptNumber);
   };
 
   return (
@@ -64,7 +68,7 @@ const ActiveCaseList = (props: Props) => {
         previouslySnoozedCases={summary.PREVIOUSLY_SNOOZED || 0}
       />
       <CaseList
-        cases={cases}
+        cases={caselist}
         headers={[
           { key: "showDetails", props: { toggleDetails } },
           { key: "receiptNumber" },
@@ -93,4 +97,7 @@ const ActiveCaseList = (props: Props) => {
   );
 };
 
-export { ActiveCaseList };
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(UnconnectedActiveCaseList);

--- a/src/view/util/__test__/formattedDate.test.tsx
+++ b/src/view/util/__test__/formattedDate.test.tsx
@@ -3,6 +3,12 @@ import { mount } from "enzyme";
 import FormattedDate from "../FormattedDate";
 
 describe("FormattedDate", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "error").mockImplementation(() => null);
+  });
+  afterEach(() => {
+    (console.error as jest.Mock).mockRestore();
+  });
   it("should return null when a date is missing", () => {
     const wrapper = mount(<FormattedDate label="a" />);
     expect(wrapper.html()).toBe(null);


### PR DESCRIPTION
## Proposed change

* Add `cases` redux module
* Moves much of the stateful logic from `ActiveCaseList` and `SnoozedCaseList` to redux (These two components are now looking very similar; can likely be merged soon).

There is other stateful case logic (e.g., snoozing/resnoozing/ending snooze), but didn't want to touch _too_ much in any single PR.