### PR TITLE
Modest tweaks to attachment display.

### DIFF
--- a/src/stories/DetailNoteDisplay.stories.jsx
+++ b/src/stories/DetailNoteDisplay.stories.jsx
@@ -5,6 +5,7 @@ import { DetailNoteDisplay } from "../view/tables/DetailNoteDisplay";
 storiesOf("DetailNoteDisplay", module)
   .add("Trouble ticket", () => {
     const note = {
+      type: "LINK",
       subType: "troubleticket",
       href: "http://localhost:1111/12345",
       content: "12345"
@@ -13,6 +14,7 @@ storiesOf("DetailNoteDisplay", module)
   })
   .add("Assignee", () => {
     const note = {
+      type: "TAG",
       subType: "assignee",
       content: "Joe"
     };
@@ -20,6 +22,7 @@ storiesOf("DetailNoteDisplay", module)
   })
   .add("General comment", () => {
     const note = {
+      type: "COMMENT",
       content: "This is a general comment."
     };
     return <DetailNoteDisplay caseDetail={note} />;

--- a/src/stories/__snapshots__/storyshots.test.js.snap
+++ b/src/stories/__snapshots__/storyshots.test.js.snap
@@ -296,7 +296,6 @@ Array [
   <a
     href="http://localhost:1111/12345"
   >
-    #
     12345
   </a>,
   " was associated with this case.",

--- a/src/view/tables/CaseDetailList.tsx
+++ b/src/view/tables/CaseDetailList.tsx
@@ -11,6 +11,12 @@ const CaseDetailList: React.FC<CaseDetailListProps> = props => {
   return (
     <div className="grid-container case-detail-list">
       {props.caseDetails.map((caseDetail, index) => {
+        if (
+          caseDetail.noteOrSnooze === "note" &&
+          caseDetail.type === "CORRELATION_ID"
+        ) {
+          return null;
+        }
         return (
           <div className="grid-row" key={index}>
             <div className="grid-col-auto case-detail-date">

--- a/src/view/tables/DetailNoteDisplay.tsx
+++ b/src/view/tables/DetailNoteDisplay.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React from "react";
 
 interface DetailNoteDisplayProps {
   caseDetail: CaseDetail;

--- a/src/view/tables/DetailNoteDisplay.tsx
+++ b/src/view/tables/DetailNoteDisplay.tsx
@@ -62,7 +62,10 @@ const DetailNoteDisplay: React.FunctionComponent<
           );
       }
     case "CORRELATION_ID":
-      // this should never be reached: the parent component should intercept it
+      // this should never be reached: the parent component should intercept it and avoid calling this component
+      console.error(
+        "Reached display branch for CORRELATION_ID attachment, which should never happen!"
+      );
       return null;
   }
   return (

--- a/src/view/tables/DetailNoteDisplay.tsx
+++ b/src/view/tables/DetailNoteDisplay.tsx
@@ -9,38 +9,61 @@ const DetailNoteDisplay: React.FunctionComponent<
 > = props => {
   const { caseDetail } = props;
 
-  switch (caseDetail.subType) {
-    case "troubleticket":
-      if (caseDetail.href) {
-        return (
-          <React.Fragment>
-            ServiceNow ticket{" "}
-            <a href={caseDetail.href}>#{caseDetail.content}</a> was associated
-            with this case.
-          </React.Fragment>
-        );
-      } else {
-        console.error("Attemptrouble case without href");
+  switch (caseDetail.type) {
+    case "COMMENT":
+      break;
+    case "LINK":
+      if (!caseDetail.href) {
+        console.error("LINK without href");
         break;
       }
-    case "assignee":
-      return (
-        <React.Fragment>
-          {`${caseDetail.content} was assigned to follow-up on this case.`}
-        </React.Fragment>
-      );
-    case "fieldoffice":
-      return (
-        <React.Fragment>
-          {`Stuck at Field Office: ${caseDetail.content}`}
-        </React.Fragment>
-      );
-    case "referral":
-      return (
-        <React.Fragment>
-          {`Referred beacause: ${caseDetail.content}`}
-        </React.Fragment>
-      );
+      switch (caseDetail.subType) {
+        case "troubleticket":
+          return (
+            <React.Fragment>
+              ServiceNow ticket{" "}
+              <a href={caseDetail.href}>{caseDetail.content}</a> was associated
+              with this case.
+            </React.Fragment>
+          );
+        default:
+          return (
+            <React.Fragment>
+              Link <a href={caseDetail.href}>{caseDetail.content}</a> was
+              associated with this case.
+            </React.Fragment>
+          );
+      }
+    case "TAG":
+      switch (caseDetail.subType) {
+        case "assignee":
+          return (
+            <React.Fragment>
+              {`${caseDetail.content} was assigned to follow-up on this case.`}
+            </React.Fragment>
+          );
+        case "fieldoffice":
+          return (
+            <React.Fragment>
+              {`Stuck at Field Office: ${caseDetail.content}`}
+            </React.Fragment>
+          );
+        case "referral":
+          return (
+            <React.Fragment>
+              {`Referred beacause: ${caseDetail.content}`}
+            </React.Fragment>
+          );
+        default:
+          return (
+            <React.Fragment>
+              {`Tagged as: ${caseDetail.content}`}
+            </React.Fragment>
+          );
+      }
+    case "CORRELATION_ID":
+      // this should never be reached: the parent component should intercept it
+      return null;
   }
   return (
     <React.Fragment>


### PR DESCRIPTION
Removed the "#" from the link text for trouble tickets, did a possibly excessive refactor to reflect the type/subtype structure of a attachments a little more clearly, and skipped display of correlation IDs, since they don't actually matter to end users right now.