### PR TITLE
Tim best/docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,30 +1,20 @@
-# Javascript Node CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-javascript/ for more details
-#
 version: 2
 jobs:
   build:
     docker:
-      # specify the version you desire here
       - image: circleci/node:12.9.1
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mongo:3.4.4
     working_directory: ~/repo
     steps:
       - checkout
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-      - run: yarn install
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
-      # run tests!
-      - run: yarn run ci-checks
+      - setup_remote_docker
+      - run:
+          name: Build test image
+          command: |
+            docker-compose -f docker-compose.test.yml build
+      - run:
+          name: Run all checks
+          command: |
+            docker-compose -f docker-compose.test.yml up --exit-code-from test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:12-alpine
+
+RUN npm install -g yarn@1.17.3
+
+COPY . /home/src
+
+WORKDIR /home/src
+
+RUN yarn install
+
+ENTRYPOINT yarn run start

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,28 @@
 FROM node:12-alpine
 
-RUN npm install -g yarn@1.17.3
+# remove preinstall version of yarn
+RUN rm -rf /usr/local/bin/yarn && rm -rf /usr/local/bin/yarnpkg
+
+# install required yarn version
+# coppied from https://github.com/nodejs/docker-node/blob/ab3d54cef9f236ed9792aa4b786215db9ee7c1b6/12/alpine3.11/Dockerfile#L72
+ENV YARN_VERSION 1.17.3
+RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && apk del .build-deps-yarn
 
 COPY . /home/src
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  test:
+    build:
+      context: .
+      dockerfile: test.Dockerfile
+    container_name: "test"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3"
+services:
+  navigator:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: "navigator"
+    ports:
+      # This is externalPort:internalPort, for the record
+      - "3000:3000"

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,11 @@ In the project directory, you can run:
 
 ### `yarn start`
 
+```bash
+docker-compose build
+docker-compose up
+```
+
 Runs the app in the development mode.
 
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
@@ -35,6 +40,13 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 The page will reload if you make edits.
 
 You will also see any lint errors in the console.
+
+### CI-checks
+
+```bash
+docker-compose -f docker-compose.test.yml build
+docker-compose -f docker-compose.test.yml up
+```
 
 ### `yarn test`
 

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,0 +1,11 @@
+FROM node:12-alpine
+
+RUN npm install -g yarn@1.17.3
+
+COPY . /home/src
+
+WORKDIR /home/src
+
+RUN yarn install
+
+ENTRYPOINT yarn run ci-checks

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,6 +1,28 @@
 FROM node:12-alpine
 
-RUN npm install -g yarn@1.17.3
+# remove preinstall version of yarn
+RUN rm -rf /usr/local/bin/yarn && rm -rf /usr/local/bin/yarnpkg
+
+# install required yarn version
+# coppied from https://github.com/nodejs/docker-node/blob/ab3d54cef9f236ed9792aa4b786215db9ee7c1b6/12/alpine3.11/Dockerfile#L72
+ENV YARN_VERSION 1.17.3
+RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && apk del .build-deps-yarn
 
 COPY . /home/src
 


### PR DESCRIPTION
adds docker image for `yarn start` and `yarn ci-checks`. 

To help ensure one source of truth this PR converts our circle-ci setup to use the test docker image 

future improvements recorded here: https://trello.com/c/BOOPzzOA