### PR TITLE
Convert frontend to use the api/cases

### DIFF
--- a/src/__test__/integration/apiMockUtils.ts
+++ b/src/__test__/integration/apiMockUtils.ts
@@ -32,8 +32,9 @@ export const successfulLoadAPIMock = () => {
     .persist();
 
   apiMock
-    .get(`/api/cases/${caseManagementSystem}/${caseType}/active`)
-    .query(true)
+    .get(
+      `/api/cases/${caseManagementSystem}/${caseType}?mainFilter=ACTIVE&size=20`
+    )
     .reply(200, activeCases);
 
   return apiMock;
@@ -54,8 +55,9 @@ export const unsuccessfulLoadAPIMock = () => {
     .reply(401, {});
 
   apiMock
-    .get(`/api/cases/${caseManagementSystem}/${caseType}/active`)
-    .query(true)
+    .get(
+      `/api/cases/${caseManagementSystem}/${caseType}?mainFilter=ACTIVE&size=20`
+    )
     .reply(401, []);
 
   return apiMock;

--- a/src/api/URLs.ts
+++ b/src/api/URLs.ts
@@ -39,13 +39,25 @@ class URLs {
     return url;
   }
 
-  public static cases(snoozeState: SnoozeState, receiptNumber?: string): URL {
+  public static cases(
+    filter: CaseSnoozeFilter,
+    receiptNumber?: string,
+    from?: Date,
+    to?: Date
+  ): URL {
     const url = URLs.casesBase();
-    url.pathname += "/" + snoozeState;
-    if (receiptNumber) {
-      url.searchParams.append("receiptNumber", receiptNumber);
-    }
+    url.searchParams.append("mainFilter", filter);
     url.searchParams.append("size", String(this.resultsPerPage));
+
+    if (receiptNumber) {
+      url.searchParams.append("pageReference", receiptNumber);
+    }
+    if (from) {
+      url.searchParams.append("caseCreationRangeBegin", from.toISOString());
+    }
+    if (to) {
+      url.searchParams.append("caseCreationRangeEnd", to.toISOString());
+    }
     return url;
   }
 

--- a/src/api/__test__/URLs.test.ts
+++ b/src/api/__test__/URLs.test.ts
@@ -22,15 +22,15 @@ describe("URLs", () => {
 
   it("should producte the correct active cases path", () => {
     expectURLEquals(
-      URLs.cases("active", "ABC1234567890"),
-      "/api/cases/DEFAULT/STANDARD/active?receiptNumber=ABC1234567890&size=20"
+      URLs.cases("ACTIVE", "ABC1234567890"),
+      "/api/cases/DEFAULT/STANDARD?mainFilter=ACTIVE&size=20&pageReference=ABC1234567890"
     );
   });
 
   it("should producte the correct snooze cases path", () => {
     expectURLEquals(
-      URLs.cases("snoozed", "ABC1234567890"),
-      "/api/cases/DEFAULT/STANDARD/snoozed?receiptNumber=ABC1234567890&size=20"
+      URLs.cases("SNOOZED", "ABC1234567890"),
+      "/api/cases/DEFAULT/STANDARD?mainFilter=SNOOZED&size=20&pageReference=ABC1234567890"
     );
   });
 

--- a/src/api/resources/CaseIssueAPIClient.ts
+++ b/src/api/resources/CaseIssueAPIClient.ts
@@ -10,16 +10,15 @@ interface SummarySuccess {
 }
 
 class CaseIssueAPIClient extends ClientBase {
-  public async getActive(
-    receiptNumber?: string
+  public async getCases(
+    filter: CaseSnoozeFilter,
+    receiptNumber?: string,
+    from?: Date,
+    to?: Date
   ): Promise<c.ApiResponse<Case[], APIError>> {
-    return (await this.getAsJson(URLs.cases("active", receiptNumber))) as any;
-  }
-
-  public async getSnoozed(
-    receiptNumber?: string
-  ): Promise<c.ApiResponse<Case[], APIError>> {
-    return (await this.getAsJson(URLs.cases("snoozed", receiptNumber))) as any;
+    return (await this.getAsJson(
+      URLs.cases(filter, receiptNumber, from, to)
+    )) as any;
   }
 
   public async getCaseSummary(): Promise<c.ApiResponse<SummarySuccess, {}>> {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,6 +16,8 @@ type CaseManagementSystem = "DEFAULT";
 type CaseType = "STANDARD";
 type SubType = "troubleticket" | "assignee" | "fieldoffice" | "referral";
 
+type CaseSnoozeFilter = "ACTIVE" | "SNOOZED" | "ALARMED";
+
 interface Views {
   CASES_TO_WORK: {
     title: "Cases to Work";

--- a/src/redux/modules/__test__/cases.test.ts
+++ b/src/redux/modules/__test__/cases.test.ts
@@ -313,7 +313,7 @@ describe("redux - cases", () => {
     await loadCases()(dispatch, getState);
     expect(dispatch).toHaveBeenCalledWith(addCases(initialCases));
   });
-  it("calls getCases without a recipetnumber when there are no cases", async () => {
+  it("calls getCases without a receiptNumber when there are no cases", async () => {
     jest.spyOn(RestAPIClient.cases, "getCases");
     const { dispatch, getState } = store;
     const summary: Summary = {
@@ -330,7 +330,7 @@ describe("redux - cases", () => {
       undefined
     );
   });
-  it("calls getCases with a recipetnumber when there is a case", async () => {
+  it("calls getCases with a receiptNumber when there is a case", async () => {
     jest.spyOn(RestAPIClient.cases, "getCases");
     const { dispatch, getState } = store;
     const summary: Summary = {

--- a/src/redux/modules/__test__/cases.test.ts
+++ b/src/redux/modules/__test__/cases.test.ts
@@ -313,8 +313,8 @@ describe("redux - cases", () => {
     await loadCases()(dispatch, getState);
     expect(dispatch).toHaveBeenCalledWith(addCases(initialCases));
   });
-  it("calls getActive without a recipetnumber when there are no cases", async () => {
-    jest.spyOn(RestAPIClient.cases, "getActive");
+  it("calls getCases without a recipetnumber when there are no cases", async () => {
+    jest.spyOn(RestAPIClient.cases, "getCases");
     const { dispatch, getState } = store;
     const summary: Summary = {
       CASES_TO_WORK: 15,
@@ -325,10 +325,13 @@ describe("redux - cases", () => {
     dispatch(clearCases());
     dispatch(setCaseType("active"));
     await loadCases()(dispatch, getState);
-    expect(RestAPIClient.cases.getActive).toHaveBeenCalledWith(undefined);
+    expect(RestAPIClient.cases.getCases).toHaveBeenCalledWith(
+      "ACTIVE",
+      undefined
+    );
   });
-  it("calls getActive with a recipetnumber when there is a case", async () => {
-    jest.spyOn(RestAPIClient.cases, "getActive");
+  it("calls getCases with a recipetnumber when there is a case", async () => {
+    jest.spyOn(RestAPIClient.cases, "getCases");
     const { dispatch, getState } = store;
     const summary: Summary = {
       CASES_TO_WORK: 15,
@@ -340,7 +343,8 @@ describe("redux - cases", () => {
     dispatch(addCases(initialCases));
     dispatch(setCaseType("active"));
     await loadCases()(dispatch, getState);
-    expect(RestAPIClient.cases.getActive).toHaveBeenCalledWith(
+    expect(RestAPIClient.cases.getCases).toHaveBeenCalledWith(
+      "ACTIVE",
       initialCases[initialCases.length - 1].receiptNumber
     );
   });

--- a/src/redux/modules/casesAsync.ts
+++ b/src/redux/modules/casesAsync.ts
@@ -21,8 +21,8 @@ export const loadCases = () => async (
   dispatch(getCaseSummary());
   const response =
     type === "active"
-      ? await RestAPIClient.cases.getActive(lastReceiptNumber)
-      : await RestAPIClient.cases.getSnoozed(lastReceiptNumber);
+      ? await RestAPIClient.cases.getCases("ACTIVE", lastReceiptNumber)
+      : await RestAPIClient.cases.getCases("SNOOZED", lastReceiptNumber);
   dispatch(setIsLoading(false));
 
   if (response.succeeded) {


### PR DESCRIPTION
This PR will allow the API to remove 
`/api/cases/{caseManagementSystemTag}/{caseTypeTag}/active`
and 
`/api/cases/{caseManagementSystemTag}/{caseTypeTag}/snoozed`


Depends on https://github.com/usds/case-issue-api/pull/82