### PR TITLE
Adds resultsPerPage+1 logic to determine if there are more results to show`

### DIFF
--- a/src/__test__/integration/apiMockUtils.ts
+++ b/src/__test__/integration/apiMockUtils.ts
@@ -1,6 +1,7 @@
 import { API_BASE_URL } from "../../controller/config";
 import nock from "nock";
 import { activeCases } from "./fakeData";
+import { RESULTS_PER_PAGE } from "../../api/URLs";
 
 const caseManagementSystem = process.env.REACT_APP_CASE_MANAGEMENT_SYSTEM;
 const caseType = process.env.REACT_APP_CASE_TYPE;
@@ -33,7 +34,8 @@ export const successfulLoadAPIMock = () => {
 
   apiMock
     .get(
-      `/api/cases/${caseManagementSystem}/${caseType}?mainFilter=ACTIVE&size=20`
+      `/api/cases/${caseManagementSystem}/${caseType}?mainFilter=ACTIVE&size=${RESULTS_PER_PAGE +
+        1}`
     )
     .reply(200, activeCases);
 

--- a/src/api/URLs.ts
+++ b/src/api/URLs.ts
@@ -1,12 +1,15 @@
 import { API_BASE_URL } from "../controller/config";
 
+export const RESULTS_PER_PAGE: number = 20;
+
 class URLs {
   private static caseManagementSystem: CaseManagementSystem =
     (process.env.REACT_APP_CASE_MANAGEMENT_SYSTEM as CaseManagementSystem) ||
     "DEFAULT";
   private static caseType: CaseType =
     (process.env.REACT_APP_CASE_TYPE as CaseType) || "STANDARD";
-  private static resultsPerPage: number = 20;
+  // Add 1 to resultsPerPage to see if there are more results
+  private static resultsPerPage: number = RESULTS_PER_PAGE + 1;
 
   private static baseUrl(path: string): URL {
     return new URL(API_BASE_URL + path);

--- a/src/api/__test__/URLs.test.ts
+++ b/src/api/__test__/URLs.test.ts
@@ -1,4 +1,4 @@
-import URLs from "../URLs";
+import URLs, { RESULTS_PER_PAGE } from "../URLs";
 
 const TEST_URL = "http://localhost:8080";
 
@@ -22,14 +22,16 @@ describe("URLs", () => {
   it("should producte the correct active cases path", () => {
     expectURLEquals(
       URLs.cases("ACTIVE", "ABC1234567890"),
-      "/api/cases/DEFAULT/STANDARD?mainFilter=ACTIVE&size=20&pageReference=ABC1234567890"
+      `/api/cases/DEFAULT/STANDARD?mainFilter=ACTIVE&size=${RESULTS_PER_PAGE +
+        1}&pageReference=ABC1234567890`
     );
   });
 
   it("should producte the correct snooze cases path", () => {
     expectURLEquals(
       URLs.cases("SNOOZED", "ABC1234567890"),
-      "/api/cases/DEFAULT/STANDARD?mainFilter=SNOOZED&size=20&pageReference=ABC1234567890"
+      `/api/cases/DEFAULT/STANDARD?mainFilter=SNOOZED&size=${RESULTS_PER_PAGE +
+        1}&pageReference=ABC1234567890`
     );
   });
 
@@ -41,14 +43,16 @@ describe("URLs", () => {
         new Date("2/4/2018"),
         new Date("3/5/2019")
       ),
-      "/api/cases/DEFAULT/STANDARD?mainFilter=SNOOZED&size=20&caseCreationRangeBegin=2018-02-04T05%3A00%3A00.000Z&caseCreationRangeEnd=2019-03-05T05%3A00%3A00.000Z"
+      `/api/cases/DEFAULT/STANDARD?mainFilter=SNOOZED&size=${RESULTS_PER_PAGE +
+        1}&caseCreationRangeBegin=2018-02-04T05%3A00%3A00.000Z&caseCreationRangeEnd=2019-03-05T05%3A00%3A00.000Z`
     );
   });
 
   it("should producte the correct snooze cases path with snooze reason", () => {
     expectURLEquals(
       URLs.cases("SNOOZED", undefined, undefined, undefined, "test_data"),
-      "/api/cases/DEFAULT/STANDARD?mainFilter=SNOOZED&size=20&snoozeReason=test_data"
+      `/api/cases/DEFAULT/STANDARD?mainFilter=SNOOZED&size=${RESULTS_PER_PAGE +
+        1}&snoozeReason=test_data`
     );
   });
 

--- a/src/redux/modules/cases.ts
+++ b/src/redux/modules/cases.ts
@@ -42,7 +42,9 @@ export const casesActionCreators = {
   setSnoozeReasonFilter: (snoozeReason?: SnoozeReason) =>
     action("cases/SET_SNOOZE_REASON_FILTER", snoozeReason),
   setServiceNowFilter: (serviceNowFilter?: boolean) =>
-    action("cases/SET_SERVICE_NOW_FILTER", serviceNowFilter)
+    action("cases/SET_SERVICE_NOW_FILTER", serviceNowFilter),
+  setHasMoreCases: (hasMoreCases: boolean) =>
+    action("cases/SET_HAS_MORE_CASES", hasMoreCases)
 };
 
 export type ActionCreator = typeof casesActionCreators;
@@ -55,6 +57,7 @@ export type CasesState = {
   type: SnoozeState;
   isLoading: boolean;
   summary: Summary;
+  hasMoreCases: boolean;
   lastUpdated?: string;
   caseCreationStart?: Date;
   caseCreationEnd?: Date;
@@ -70,7 +73,8 @@ export const initialState: CasesState = {
     CASES_TO_WORK: 0,
     SNOOZED_CASES: 0,
     PREVIOUSLY_SNOOZED: 0
-  }
+  },
+  hasMoreCases: true
 };
 
 // Reducer
@@ -204,6 +208,8 @@ export default function reducer(
         search: `?${urlP.toString()}`
       });
       return { ...state, serviceNowFilter: action.payload };
+    case "cases/SET_HAS_MORE_CASES":
+      return { ...state, hasMoreCases: action.payload };
     default:
       return state;
   }

--- a/src/redux/modules/casesAsync.ts
+++ b/src/redux/modules/casesAsync.ts
@@ -4,6 +4,7 @@ import RestAPIClient from "../../api/RestAPIClient";
 import { casesActionCreators } from "./cases";
 import { ThunkDispatch } from "redux-thunk";
 import NoteUtils from "../../utils/NoteUtils";
+import { RESULTS_PER_PAGE } from "../../api/URLs";
 
 const serviceNowCaseFilter = (c: Case) => {
   if (
@@ -22,7 +23,7 @@ export const loadCases = (reciptnumber?: string) => async (
   dispatch: ThunkDispatch<RootState, {}, AnyAction>,
   getState: () => RootState
 ) => {
-  const { setIsLoading, addCases } = casesActionCreators;
+  const { setIsLoading, addCases, setHasMoreCases } = casesActionCreators;
   const { cases } = getState();
   const {
     caselist,
@@ -58,6 +59,13 @@ export const loadCases = (reciptnumber?: string) => async (
   dispatch(setIsLoading(false));
 
   if (response.succeeded) {
+    if (response.payload.length > RESULTS_PER_PAGE) {
+      response.payload.pop();
+      dispatch(setHasMoreCases(true));
+    } else {
+      dispatch(setHasMoreCases(false));
+    }
+
     if (type === "snoozed" && serviceNowFilter !== undefined) {
       const cases = serviceNowFilter
         ? response.payload.filter((c: Case) => {

--- a/src/stories/__snapshots__/storyshots.test.js.snap
+++ b/src/stories/__snapshots__/storyshots.test.js.snap
@@ -640,14 +640,6 @@ exports[`Storyshots LoadMore more cases loading 1`] = `
 </div>
 `;
 
-exports[`Storyshots LoadMore no cases 1`] = `
-<div
-  className="display-flex flex-column flex-align-center"
->
-  There are no more cases on this list.
-</div>
-`;
-
 exports[`Storyshots LoadMore no more cases 1`] = `
 <div
   className="display-flex flex-column flex-align-center"

--- a/src/stories/layout/LoadMore.stories.jsx
+++ b/src/stories/layout/LoadMore.stories.jsx
@@ -2,36 +2,15 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import LoadMore from "../../view/layout/LoadMore";
 
+const onClick = () => undefined;
+
 storiesOf("LoadMore", module)
-  .add("no cases", () => (
-    <LoadMore
-      totalCases={0}
-      loadedCases={0}
-      isLoading={false}
-      onClick={() => undefined}
-    />
-  ))
   .add("no more cases", () => (
-    <LoadMore
-      totalCases={14000}
-      loadedCases={14000}
-      isLoading={false}
-      onClick={() => undefined}
-    />
+    <LoadMore hasMoreCases={false} isLoading={false} onClick={onClick} />
   ))
   .add("more cases", () => (
-    <LoadMore
-      totalCases={14000}
-      loadedCases={20}
-      isLoading={false}
-      onClick={() => undefined}
-    />
+    <LoadMore hasMoreCases={true} isLoading={false} onClick={onClick} />
   ))
   .add("more cases loading", () => (
-    <LoadMore
-      totalCases={14000}
-      loadedCases={20}
-      isLoading={true}
-      onClick={() => undefined}
-    />
+    <LoadMore hasMoreCases={true} isLoading={true} onClick={onClick} />
   ));

--- a/src/view/CaseList.tsx
+++ b/src/view/CaseList.tsx
@@ -21,7 +21,8 @@ const mapStateToProps = (state: RootState) => ({
   caselist: state.cases.caselist,
   isLoading: state.cases.isLoading,
   summary: state.cases.summary,
-  lastUpdated: state.cases.lastUpdated
+  lastUpdated: state.cases.lastUpdated,
+  hasMoreCases: state.cases.hasMoreCases
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) =>
@@ -131,8 +132,7 @@ class CaseList extends React.Component<Props, State> {
         <CaseFilterForm snoozeState={this.props.snoozeState} />
         <I90Table />
         <LoadMore
-          totalCases={this.getTotalCases()}
-          loadedCases={this.props.caselist.length}
+          hasMoreCases={this.props.hasMoreCases}
           isLoading={this.props.isLoading}
           onClick={() => this.props.loadCases()}
         />

--- a/src/view/layout/LoadMore.tsx
+++ b/src/view/layout/LoadMore.tsx
@@ -2,17 +2,16 @@ import React from "react";
 import UsaButton from "../util/UsaButton";
 
 interface Props {
-  totalCases: number;
-  loadedCases: number;
   isLoading: boolean;
+  hasMoreCases: boolean;
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 const LoadMore: React.FunctionComponent<Props> = props => {
-  const { loadedCases, totalCases, isLoading, onClick } = props;
+  const { hasMoreCases, isLoading, onClick } = props;
 
   const renderLoadMoreAction = () => {
-    if (totalCases > loadedCases) {
+    if (hasMoreCases) {
       return (
         <UsaButton onClick={onClick} disabled={isLoading} buttonStyle="outline">
           {isLoading ? "Loading..." : "Show More"}

--- a/src/view/layout/__test__/LoadMore.test.tsx
+++ b/src/view/layout/__test__/LoadMore.test.tsx
@@ -6,8 +6,7 @@ describe("LoadMore", () => {
   it("should be disabled when loading more cases", () => {
     const wrapper = shallow(
       <LoadMore
-        totalCases={14000}
-        loadedCases={20}
+        hasMoreCases={true}
         isLoading={true}
         onClick={() => undefined}
       />


### PR DESCRIPTION
## Proposed changes

* Add `state.cases.hasMoreCases` prop to redux store
* Request one additional result per API call to see if there are more results
* Dispatch an action to set `hasMoreCases` based on whether the returned results are > `resultsPerPage`
* Conditionally display the "Show More" button based on the `hasMoreCases` state bool.
* Update associated tests to be more robust (there were a lot of hard-coded 20s in our case-fetching tests. Now we're fetching 21 cases, but importantly we should be fetching `RESULTS_PER_PAGE + 1` cases, so just use that variable instead of hard-coding. 