### PR TITLE
remove outdated contact info

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,3 @@ For information about setting up and using Search Party, see the *Search Party*[
 
 Please read our [Code of Conduct](https://github.com/usds/case-issue-navigator/blob/master/CODE_OF_CONDUCT.md) and [CONTRIBUTING.md](https://github.com/usds/case-issue-navigator/blob/master/CONTRIBUTING.md) for more details.
 
-
-
-**Contact the project team:**
-
-If you want to directly contact the project team, you can send your questions to search-party-group@usds.dhs.gov.


### PR DESCRIPTION
Remove reference to search-party-group@usds.dhs.gov. Why: that account is inactive or not receiving emails from other domains.